### PR TITLE
Defer goal continuation while background tasks are active

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Server options can be configured in `opencode.json`:
       "@prevalentware/opencode-goal-plugin",
       {
         "auto_continue": true,
+        "defer_while_tasks_active": true,
         "max_auto_turns": 25,
         "min_continue_interval_seconds": 3,
         "max_prompt_failures": 3,
@@ -98,6 +99,7 @@ Server options can be configured in `opencode.json`:
 Defaults:
 
 - `auto_continue`: `true`
+- `defer_while_tasks_active`: `true`; when enabled, goal auto-continuation waits for active OpenCode Task child sessions and their orchestrator reconciliation before sending the next goal prompt.
 - `max_auto_turns`: `25`
 - `min_continue_interval_seconds`: `3`
 - `max_prompt_failures`: `3`
@@ -194,6 +196,6 @@ OpenCode plugin modules are target-specific. This package exports separate modul
 }
 ```
 
-Codex goal mode has deeper runtime integration for thread lifecycle control. This plugin implements the same workflow using OpenCode plugin hooks. Token usage is read from OpenCode step-finish usage when available and falls back to message token metadata or text estimation when exact usage is unavailable. Continuation is driven by OpenCode idle events, including `session.idle` and `session.status` idle notifications. During compaction, the plugin disables OpenCode's generic synthetic auto-continue while an active goal exists so the goal-specific continuation prompt remains authoritative.
+Codex goal mode has deeper runtime integration for thread lifecycle control. This plugin implements the same workflow using OpenCode plugin hooks. Token usage is read from OpenCode step-finish usage when available and falls back to message token metadata or text estimation when exact usage is unavailable. Continuation is driven by OpenCode idle events, including `session.idle` and `session.status` idle notifications. By default, continuation is deferred while OpenCode Task child sessions are active or their terminal result still needs an orchestrator turn. During compaction, the plugin disables OpenCode's generic synthetic auto-continue while an active goal exists so the goal-specific continuation prompt remains authoritative.
 
 The goal sidebar shows the current status, elapsed time, token usage, auto-continue count, latest checkpoint, latest status message, stop reason, and objective when a goal is active, paused, or safety-limited. Closed goals remain visible briefly through the latest tool state as achieved or unmet.

--- a/dist/server.js
+++ b/dist/server.js
@@ -701,6 +701,8 @@ var DEFAULT_CONTINUE_INTERVAL_SECONDS = 3;
 var DEFAULT_MAX_PROMPT_FAILURES = 3;
 var DEFAULT_COMMAND_NAME = "goal";
 var GOAL_SYSTEM_MARKER = "OpenCode goal mode";
+var TASK_SETTLE_DELAY_MS = 25;
+var TASK_TERMINAL_STATES = new Set(["completed", "error", "cancelled"]);
 var activeContinuations = new Set;
 function goalCommandTemplate(commandName) {
   return `OpenCode goal mode command "/${commandName}" was invoked.
@@ -757,6 +759,16 @@ function textFromMessage(message) {
   return (message.parts ?? []).map(textFromPart).filter(Boolean).join(`
 `).trim();
 }
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+function sessionIDFromMessage(message) {
+  if (typeof message.sessionID === "string")
+    return message.sessionID;
+  if (isRecord(message.info) && typeof message.info.sessionID === "string")
+    return message.info.sessionID;
+  return;
+}
 function estimateMessages(messages) {
   return messages.reduce((sum, message) => sum + estimateTokensFromText(textFromMessage(message)), 0);
 }
@@ -810,6 +822,52 @@ function tokensFromMessages(messages) {
   const exactTotal = messages.reduce((sum, message) => sum + (exactTokensFromMessage(message) ?? 0), 0);
   return exactTotal > 0 ? exactTotal : estimateMessages(messages);
 }
+function taskHeader(output) {
+  const resultIndex = output.search(/<task_(?:result|error)>/);
+  return resultIndex === -1 ? output : output.slice(0, resultIndex);
+}
+function parseTaskID(output) {
+  const xmlMatch = /<task\s+[^>]*\bid=["']([^"']+)["'][^>]*>/i.exec(output);
+  if (xmlMatch?.[1])
+    return xmlMatch[1];
+  for (const line of output.split(/\r?\n/)) {
+    const match = /^task_id:\s*([^\s()]+)(?:\s*\(.*)?$/i.exec(line.trim());
+    if (match?.[1])
+      return match[1];
+  }
+  return;
+}
+function parseTaskState(output) {
+  const xmlMatch = /<task\s+[^>]*\bstate=["'](running|completed|error|cancelled)["'][^>]*>/i.exec(output);
+  if (xmlMatch?.[1])
+    return xmlMatch[1].toLowerCase();
+  for (const line of taskHeader(output).split(/\r?\n/)) {
+    const match = /^state:\s*(running|completed|error|cancelled)\s*$/i.exec(line.trim());
+    if (match?.[1])
+      return match[1].toLowerCase();
+  }
+  return;
+}
+function parseTaskStatus(output) {
+  if (typeof output !== "string")
+    return;
+  const taskID = parseTaskID(output);
+  const state = parseTaskState(output);
+  return taskID && state ? { taskID, state } : undefined;
+}
+function messageCompletedAt(message) {
+  const time = isRecord(message.time) ? message.time : isRecord(message.info) && isRecord(message.info.time) ? message.info.time : undefined;
+  const completed = time?.completed;
+  return typeof completed === "number" && Number.isFinite(completed) ? completed : null;
+}
+function assistantMarker(message) {
+  if (messageRole(message) !== "assistant")
+    return;
+  return {
+    id: messageID(message) ?? null,
+    completedAt: messageCompletedAt(message)
+  };
+}
 async function sendContinuation(client, sessionID, prompt) {
   await client.session.promptAsync({
     path: { id: sessionID },
@@ -861,6 +919,169 @@ async function fetchLatestAssistant(client, sessionID) {
   const data = Array.isArray(result.data) ? result.data : [];
   return latestAssistantMessage(data);
 }
+
+class TaskTracker {
+  tasks = new Map;
+  pendingTaskCalls = new Map;
+  latestAssistantBySession = new Map;
+  noteTaskCall(input) {
+    if (typeof input.tool !== "string" || input.tool.toLowerCase() !== "task")
+      return;
+    if (typeof input.sessionID !== "string")
+      return;
+    if (typeof input.callID === "string")
+      this.pendingTaskCalls.set(input.callID, input.sessionID);
+  }
+  noteTaskOutput(input, output) {
+    if (typeof input.tool !== "string" || input.tool.toLowerCase() !== "task")
+      return;
+    const parentSessionID = typeof input.callID === "string" ? this.pendingTaskCalls.get(input.callID) ?? input.sessionID : input.sessionID;
+    if (typeof input.callID === "string")
+      this.pendingTaskCalls.delete(input.callID);
+    if (typeof parentSessionID !== "string")
+      return;
+    const status = parseTaskStatus(output.output);
+    if (!status)
+      return;
+    if (status.state === "running") {
+      this.markRunning(parentSessionID, status.taskID);
+      return;
+    }
+    this.markTerminal(status.taskID, status.state);
+  }
+  observeSessionCreated(event) {
+    const info = event.properties?.info;
+    if (!isRecord(info) || typeof info.id !== "string" || typeof info.parentID !== "string")
+      return;
+    this.markRunning(info.parentID, info.id);
+  }
+  observeSessionStatus(sessionID, status) {
+    const task = this.tasks.get(sessionID);
+    if (!task)
+      return;
+    if (status === "busy") {
+      this.markRunning(task.parentSessionID, sessionID);
+      return;
+    }
+    if (status === "idle")
+      this.markTerminal(sessionID, "completed");
+  }
+  observeSessionDeleted(sessionID) {
+    this.tasks.delete(sessionID);
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionID === sessionID)
+        this.tasks.delete(task.taskID);
+    }
+    this.latestAssistantBySession.delete(sessionID);
+  }
+  observeMessages(messages) {
+    for (const message of messages) {
+      const sessionID = sessionIDFromMessage(message);
+      if (!sessionID)
+        continue;
+      const marker = assistantMarker(message);
+      if (marker) {
+        this.observeAssistant(sessionID, marker);
+        continue;
+      }
+      for (const part of message.parts ?? []) {
+        const status = parseTaskStatus(textFromPart(part));
+        if (!status)
+          continue;
+        if (status.state === "running")
+          this.markRunning(sessionID, status.taskID);
+        else
+          this.markTerminal(status.taskID, status.state);
+      }
+    }
+  }
+  observeAssistantMessage(sessionID, message) {
+    const marker = message ? assistantMarker(message) : undefined;
+    if (marker)
+      this.observeAssistant(sessionID, marker);
+  }
+  hasBlockingTasks(parentSessionID) {
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionID !== parentSessionID)
+        continue;
+      if (task.state === "running" || task.terminalUnreconciled)
+        return true;
+    }
+    return false;
+  }
+  async refreshLiveChildren(client, parentSessionID) {
+    const session = client.session;
+    if (!session.children || !session.status)
+      return;
+    let childIDs;
+    try {
+      const result = await session.children({ path: { id: parentSessionID } });
+      const data = Array.isArray(result) ? result : Array.isArray(result.data) ? result.data : [];
+      childIDs = data.flatMap((child) => isRecord(child) && typeof child.id === "string" ? [child.id] : []);
+    } catch {
+      return;
+    }
+    if (childIDs.length === 0)
+      return;
+    let statuses;
+    try {
+      const result = await session.status();
+      statuses = isRecord(result) && isRecord(result.data) ? result.data : isRecord(result) ? result : {};
+    } catch {
+      return;
+    }
+    for (const childID of childIDs) {
+      const status = statuses[childID];
+      const statusType = isRecord(status) && typeof status.type === "string" ? status.type : undefined;
+      if (statusType === "busy")
+        this.markRunning(parentSessionID, childID);
+      else if (statusType === "idle" && this.tasks.has(childID))
+        this.markTerminal(childID, "completed");
+    }
+  }
+  markRunning(parentSessionID, taskID) {
+    const existing = this.tasks.get(taskID);
+    this.tasks.set(taskID, {
+      taskID,
+      parentSessionID,
+      state: "running",
+      terminalUnreconciled: false,
+      terminalAt: null,
+      lastAssistantMessageIDAtTerminal: existing?.lastAssistantMessageIDAtTerminal ?? null
+    });
+  }
+  markTerminal(taskID, state) {
+    if (!TASK_TERMINAL_STATES.has(state))
+      return;
+    const existing = this.tasks.get(taskID);
+    if (!existing)
+      return;
+    this.tasks.set(taskID, {
+      ...existing,
+      state,
+      terminalUnreconciled: true,
+      terminalAt: Date.now(),
+      lastAssistantMessageIDAtTerminal: this.latestAssistantBySession.get(existing.parentSessionID)?.id ?? null
+    });
+  }
+  observeAssistant(sessionID, marker) {
+    this.latestAssistantBySession.set(sessionID, marker);
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionID !== sessionID || !task.terminalUnreconciled)
+        continue;
+      if (this.assistantReconcilesTask(task, marker)) {
+        this.tasks.set(task.taskID, { ...task, terminalUnreconciled: false });
+      }
+    }
+  }
+  assistantReconcilesTask(task, marker) {
+    if (marker.id && task.lastAssistantMessageIDAtTerminal && marker.id !== task.lastAssistantMessageIDAtTerminal)
+      return true;
+    if (marker.completedAt != null && task.terminalAt != null && marker.completedAt >= task.terminalAt)
+      return true;
+    return false;
+  }
+}
 async function recordAssistantMessage(sessionID, message, options) {
   if (!message)
     return;
@@ -887,12 +1108,75 @@ ${reminder}`;
 }
 var server = async ({ client }, options) => {
   const autoContinue = options?.auto_continue ?? true;
+  const deferWhileTasksActive = options?.defer_while_tasks_active ?? true;
   const maxAutoTurns = positiveIntegerOrNull2(options?.max_auto_turns) ?? DEFAULT_MAX_AUTO_TURNS;
   const minInterval = positiveIntegerOrNull2(options?.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS;
   const maxPromptFailures = positiveIntegerOrNull2(options?.max_prompt_failures) ?? DEFAULT_MAX_PROMPT_FAILURES;
   const registerCommand = options?.register_command ?? true;
   const commandName = commandNameFromOptions(options);
+  const taskTracker = new TaskTracker;
+  const taskDeferredSessions = new Set;
+  const scheduledContinuations = new Map;
+  async function tasksBlockContinuation(sessionID) {
+    if (!deferWhileTasksActive)
+      return false;
+    await taskTracker.refreshLiveChildren(client, sessionID);
+    return taskTracker.hasBlockingTasks(sessionID);
+  }
+  function scheduleSettledContinuation(sessionID) {
+    if (scheduledContinuations.has(sessionID))
+      return;
+    const timer = setTimeout(() => {
+      scheduledContinuations.delete(sessionID);
+      runAutoContinue(sessionID, true);
+    }, TASK_SETTLE_DELAY_MS);
+    const maybeUnref = timer;
+    if (typeof maybeUnref.unref === "function")
+      maybeUnref.unref();
+    scheduledContinuations.set(sessionID, timer);
+  }
+  async function runAutoContinue(sessionID, fromTaskDeferral = false) {
+    if (activeContinuations.has(sessionID))
+      return;
+    activeContinuations.add(sessionID);
+    try {
+      const latestAssistant = await fetchLatestAssistant(client, sessionID);
+      taskTracker.observeAssistantMessage(sessionID, latestAssistant);
+      await recordAssistantMessage(sessionID, latestAssistant, options ?? {});
+      if (await tasksBlockContinuation(sessionID)) {
+        taskDeferredSessions.add(sessionID);
+        return;
+      }
+      if (!fromTaskDeferral && taskDeferredSessions.has(sessionID)) {
+        scheduleSettledContinuation(sessionID);
+        return;
+      }
+      taskDeferredSessions.delete(sessionID);
+      const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval);
+      if (!goal)
+        return;
+      await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal));
+      await recordContinuationResult(sessionID, "success", maxPromptFailures);
+    } catch (error) {
+      await recordContinuationResult(sessionID, "failure", maxPromptFailures);
+      await client.app?.log?.({
+        body: {
+          service: "opencode-goal-plugin",
+          level: "error",
+          message: "Auto-continue failed",
+          extra: { error: error instanceof Error ? error.message : String(error) }
+        }
+      });
+    } finally {
+      activeContinuations.delete(sessionID);
+    }
+  }
   return {
+    async dispose() {
+      for (const timer of scheduledContinuations.values())
+        clearTimeout(timer);
+      scheduledContinuations.clear();
+    },
     async config(config) {
       if (!registerCommand)
         return;
@@ -1005,7 +1289,14 @@ var server = async ({ client }, options) => {
         }
       }
     },
+    async "tool.execute.before"(input) {
+      taskTracker.noteTaskCall(input);
+    },
+    async "tool.execute.after"(input, output) {
+      taskTracker.noteTaskOutput(input, output);
+    },
     async "experimental.chat.messages.transform"(input, output) {
+      taskTracker.observeMessages(output.messages);
       const sessionID = "sessionID" in input && typeof input.sessionID === "string" ? input.sessionID : output.messages.find((message) => typeof message.info.sessionID === "string")?.info.sessionID;
       if (!sessionID)
         return;
@@ -1030,38 +1321,30 @@ var server = async ({ client }, options) => {
     },
     async event({ event }) {
       const sessionID = sessionIDFromEvent(event);
+      const eventType = event.type;
+      if (eventType === "session.created") {
+        taskTracker.observeSessionCreated(event);
+      }
+      if (sessionID && eventType === "session.status") {
+        const status = event.properties?.status;
+        if (isRecord(status) && typeof status.type === "string")
+          taskTracker.observeSessionStatus(sessionID, status.type);
+      }
+      if (sessionID && eventType === "session.idle")
+        taskTracker.observeSessionStatus(sessionID, "idle");
+      if (sessionID && eventType === "session.deleted")
+        taskTracker.observeSessionDeleted(sessionID);
       if (sessionID && event.type === "message.updated") {
         const props = event.properties ?? {};
         const message = [props.info, props.message].find((value) => value && typeof value === "object");
+        taskTracker.observeAssistantMessage(sessionID, message);
         await recordAssistantMessage(sessionID, message, options ?? {});
       }
       if (!autoContinue || !isIdleEvent(event))
         return;
       if (!sessionID)
         return;
-      if (activeContinuations.has(sessionID))
-        return;
-      activeContinuations.add(sessionID);
-      try {
-        await recordAssistantMessage(sessionID, await fetchLatestAssistant(client, sessionID), options ?? {});
-        const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval);
-        if (!goal)
-          return;
-        await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal));
-        await recordContinuationResult(sessionID, "success", maxPromptFailures);
-      } catch (error) {
-        await recordContinuationResult(sessionID, "failure", maxPromptFailures);
-        await client.app?.log?.({
-          body: {
-            service: "opencode-goal-plugin",
-            level: "error",
-            message: "Auto-continue failed",
-            extra: { error: error instanceof Error ? error.message : String(error) }
-          }
-        });
-      } finally {
-        activeContinuations.delete(sessionID);
-      }
+      await runAutoContinue(sessionID);
     }
   };
 };

--- a/dist/server.js
+++ b/dist/server.js
@@ -702,6 +702,7 @@ var DEFAULT_MAX_PROMPT_FAILURES = 3;
 var DEFAULT_COMMAND_NAME = "goal";
 var GOAL_SYSTEM_MARKER = "OpenCode goal mode";
 var TASK_SETTLE_DELAY_MS = 25;
+var SNAPSHOT_IDLE_HOLD_MS = 250;
 var TASK_TERMINAL_STATES = new Set(["completed", "error", "cancelled"]);
 var activeContinuations = new Set;
 function goalCommandTemplate(commandName) {
@@ -924,6 +925,8 @@ class TaskTracker {
   tasks = new Map;
   pendingTaskCalls = new Map;
   latestAssistantBySession = new Map;
+  snapshotIdleHolds = new Map;
+  settledSnapshotIdleTasks = new Set;
   noteTaskCall(input) {
     if (typeof input.tool !== "string" || input.tool.toLowerCase() !== "task")
       return;
@@ -947,7 +950,7 @@ class TaskTracker {
       this.markRunning(parentSessionID, status.taskID);
       return;
     }
-    this.markTerminal(status.taskID, status.state);
+    this.markTerminal(status.taskID, status.state, parentSessionID, { resetReconciled: true });
   }
   observeSessionCreated(event) {
     const info = event.properties?.info;
@@ -964,7 +967,7 @@ class TaskTracker {
       return;
     }
     if (status === "idle")
-      this.markTerminal(sessionID, "completed");
+      this.markTerminal(sessionID, "completed", task.parentSessionID);
   }
   observeSessionDeleted(sessionID) {
     this.tasks.delete(sessionID);
@@ -973,6 +976,7 @@ class TaskTracker {
         this.tasks.delete(task.taskID);
     }
     this.latestAssistantBySession.delete(sessionID);
+    this.clearSnapshotIdleForSession(sessionID);
   }
   observeMessages(messages) {
     for (const message of messages) {
@@ -991,7 +995,7 @@ class TaskTracker {
         if (status.state === "running")
           this.markRunning(sessionID, status.taskID);
         else
-          this.markTerminal(status.taskID, status.state);
+          this.markTerminal(status.taskID, status.state, sessionID, { resetReconciled: true });
       }
     }
   }
@@ -1001,13 +1005,28 @@ class TaskTracker {
       this.observeAssistant(sessionID, marker);
   }
   hasBlockingTasks(parentSessionID) {
+    this.pruneExpiredSnapshotIdleHolds();
     for (const task of this.tasks.values()) {
       if (task.parentSessionID !== parentSessionID)
         continue;
       if (task.state === "running" || task.terminalUnreconciled)
         return true;
     }
+    for (const hold of this.snapshotIdleHolds.values()) {
+      if (hold.parentSessionID === parentSessionID)
+        return true;
+    }
     return false;
+  }
+  nextSnapshotIdleRetryAt(parentSessionID) {
+    this.pruneExpiredSnapshotIdleHolds();
+    let next = null;
+    for (const hold of this.snapshotIdleHolds.values()) {
+      if (hold.parentSessionID !== parentSessionID)
+        continue;
+      next = next == null ? hold.expiresAt : Math.min(next, hold.expiresAt);
+    }
+    return next;
   }
   async refreshLiveChildren(client, parentSessionID) {
     const session = client.session;
@@ -1035,12 +1054,17 @@ class TaskTracker {
       const statusType = isRecord(status) && typeof status.type === "string" ? status.type : undefined;
       if (statusType === "busy")
         this.markRunning(parentSessionID, childID);
-      else if (statusType === "idle" && this.tasks.has(childID))
-        this.markTerminal(childID, "completed");
+      else if (statusType === "idle") {
+        if (this.tasks.has(childID))
+          this.markTerminal(childID, "completed", parentSessionID);
+        else
+          this.markSnapshotIdle(parentSessionID, childID);
+      }
     }
   }
   markRunning(parentSessionID, taskID) {
     const existing = this.tasks.get(taskID);
+    this.clearSnapshotIdle(parentSessionID, taskID);
     this.tasks.set(taskID, {
       taskID,
       parentSessionID,
@@ -1050,19 +1074,62 @@ class TaskTracker {
       lastAssistantMessageIDAtTerminal: existing?.lastAssistantMessageIDAtTerminal ?? null
     });
   }
-  markTerminal(taskID, state) {
+  markTerminal(taskID, state, parentSessionID, options = {}) {
     if (!TASK_TERMINAL_STATES.has(state))
       return;
     const existing = this.tasks.get(taskID);
-    if (!existing)
+    const resolvedParentSessionID = existing?.parentSessionID ?? parentSessionID;
+    if (!resolvedParentSessionID)
       return;
+    this.clearSnapshotIdle(resolvedParentSessionID, taskID);
+    if (existing && TASK_TERMINAL_STATES.has(existing.state) && !existing.terminalUnreconciled && !options.resetReconciled) {
+      return;
+    }
     this.tasks.set(taskID, {
-      ...existing,
+      taskID,
+      parentSessionID: resolvedParentSessionID,
       state,
       terminalUnreconciled: true,
       terminalAt: Date.now(),
-      lastAssistantMessageIDAtTerminal: this.latestAssistantBySession.get(existing.parentSessionID)?.id ?? null
+      lastAssistantMessageIDAtTerminal: this.latestAssistantBySession.get(resolvedParentSessionID)?.id ?? null
     });
+  }
+  markSnapshotIdle(parentSessionID, taskID) {
+    const key = this.snapshotIdleKey(parentSessionID, taskID);
+    if (this.settledSnapshotIdleTasks.has(key) || this.snapshotIdleHolds.has(key))
+      return;
+    this.snapshotIdleHolds.set(key, {
+      taskID,
+      parentSessionID,
+      expiresAt: Date.now() + SNAPSHOT_IDLE_HOLD_MS
+    });
+  }
+  clearSnapshotIdle(parentSessionID, taskID) {
+    const key = this.snapshotIdleKey(parentSessionID, taskID);
+    this.snapshotIdleHolds.delete(key);
+    this.settledSnapshotIdleTasks.delete(key);
+  }
+  clearSnapshotIdleForSession(sessionID) {
+    for (const [key, hold] of this.snapshotIdleHolds) {
+      if (hold.taskID === sessionID || hold.parentSessionID === sessionID)
+        this.snapshotIdleHolds.delete(key);
+    }
+    for (const key of this.settledSnapshotIdleTasks) {
+      if (key.startsWith(`${sessionID}\x00`) || key.endsWith(`\x00${sessionID}`)) {
+        this.settledSnapshotIdleTasks.delete(key);
+      }
+    }
+  }
+  pruneExpiredSnapshotIdleHolds(now = Date.now()) {
+    for (const [key, hold] of this.snapshotIdleHolds) {
+      if (hold.expiresAt > now)
+        continue;
+      this.snapshotIdleHolds.delete(key);
+      this.settledSnapshotIdleTasks.add(key);
+    }
+  }
+  snapshotIdleKey(parentSessionID, taskID) {
+    return `${parentSessionID}\x00${taskID}`;
   }
   observeAssistant(sessionID, marker) {
     this.latestAssistantBySession.set(sessionID, marker);
@@ -1117,36 +1184,47 @@ var server = async ({ client }, options) => {
   const taskTracker = new TaskTracker;
   const taskDeferredSessions = new Set;
   const scheduledContinuations = new Map;
-  async function tasksBlockContinuation(sessionID) {
+  const busySessions = new Set;
+  async function taskBlockStatus(sessionID) {
     if (!deferWhileTasksActive)
       return false;
     await taskTracker.refreshLiveChildren(client, sessionID);
-    return taskTracker.hasBlockingTasks(sessionID);
+    return {
+      blocked: taskTracker.hasBlockingTasks(sessionID),
+      retryAt: taskTracker.nextSnapshotIdleRetryAt(sessionID)
+    };
   }
-  function scheduleSettledContinuation(sessionID) {
+  function scheduleSettledContinuation(sessionID, delayMs = TASK_SETTLE_DELAY_MS) {
     if (scheduledContinuations.has(sessionID))
       return;
     const timer = setTimeout(() => {
       scheduledContinuations.delete(sessionID);
       runAutoContinue(sessionID, true);
-    }, TASK_SETTLE_DELAY_MS);
+    }, Math.max(0, delayMs));
     const maybeUnref = timer;
     if (typeof maybeUnref.unref === "function")
       maybeUnref.unref();
     scheduledContinuations.set(sessionID, timer);
   }
   async function runAutoContinue(sessionID, fromTaskDeferral = false) {
+    if (busySessions.has(sessionID))
+      return;
     if (activeContinuations.has(sessionID))
       return;
     activeContinuations.add(sessionID);
     try {
       const latestAssistant = await fetchLatestAssistant(client, sessionID);
       taskTracker.observeAssistantMessage(sessionID, latestAssistant);
-      await recordAssistantMessage(sessionID, latestAssistant, options ?? {});
-      if (await tasksBlockContinuation(sessionID)) {
+      const taskStatus = await taskBlockStatus(sessionID);
+      if (taskStatus && taskStatus.blocked) {
         taskDeferredSessions.add(sessionID);
+        if (taskStatus.retryAt != null)
+          scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now());
         return;
       }
+      if (busySessions.has(sessionID))
+        return;
+      await recordAssistantMessage(sessionID, latestAssistant, options ?? {});
       if (!fromTaskDeferral && taskDeferredSessions.has(sessionID)) {
         scheduleSettledContinuation(sessionID);
         return;
@@ -1327,13 +1405,22 @@ var server = async ({ client }, options) => {
       }
       if (sessionID && eventType === "session.status") {
         const status = event.properties?.status;
-        if (isRecord(status) && typeof status.type === "string")
+        if (isRecord(status) && typeof status.type === "string") {
+          if (status.type === "busy")
+            busySessions.add(sessionID);
+          if (status.type === "idle")
+            busySessions.delete(sessionID);
           taskTracker.observeSessionStatus(sessionID, status.type);
+        }
       }
-      if (sessionID && eventType === "session.idle")
+      if (sessionID && eventType === "session.idle") {
+        busySessions.delete(sessionID);
         taskTracker.observeSessionStatus(sessionID, "idle");
-      if (sessionID && eventType === "session.deleted")
+      }
+      if (sessionID && eventType === "session.deleted") {
+        busySessions.delete(sessionID);
         taskTracker.observeSessionDeleted(sessionID);
+      }
       if (sessionID && event.type === "message.updated") {
         const props = event.properties ?? {};
         const message = [props.info, props.message].find((value) => value && typeof value === "object");

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,6 +56,7 @@ const DEFAULT_MAX_PROMPT_FAILURES = 3
 const DEFAULT_COMMAND_NAME = "goal"
 const GOAL_SYSTEM_MARKER = "OpenCode goal mode"
 const TASK_SETTLE_DELAY_MS = 25
+const SNAPSHOT_IDLE_HOLD_MS = 250
 const TASK_TERMINAL_STATES = new Set<TaskState>(["completed", "error", "cancelled"])
 const activeContinuations = new Set<string>()
 
@@ -78,6 +79,12 @@ type TaskRecord = {
   terminalUnreconciled: boolean
   terminalAt: number | null
   lastAssistantMessageIDAtTerminal: string | null
+}
+
+type SnapshotIdleHold = {
+  taskID: string
+  parentSessionID: string
+  expiresAt: number
 }
 
 function goalCommandTemplate(commandName: string) {
@@ -301,6 +308,8 @@ class TaskTracker {
   private readonly tasks = new Map<string, TaskRecord>()
   private readonly pendingTaskCalls = new Map<string, string>()
   private readonly latestAssistantBySession = new Map<string, AssistantMarker>()
+  private readonly snapshotIdleHolds = new Map<string, SnapshotIdleHold>()
+  private readonly settledSnapshotIdleTasks = new Set<string>()
 
   noteTaskCall(input: { tool?: unknown; sessionID?: unknown; callID?: unknown }) {
     if (typeof input.tool !== "string" || input.tool.toLowerCase() !== "task") return
@@ -320,7 +329,7 @@ class TaskTracker {
       this.markRunning(parentSessionID, status.taskID)
       return
     }
-    this.markTerminal(status.taskID, status.state)
+    this.markTerminal(status.taskID, status.state, parentSessionID, { resetReconciled: true })
   }
 
   observeSessionCreated(event: { properties?: Record<string, unknown> }) {
@@ -336,7 +345,7 @@ class TaskTracker {
       this.markRunning(task.parentSessionID, sessionID)
       return
     }
-    if (status === "idle") this.markTerminal(sessionID, "completed")
+    if (status === "idle") this.markTerminal(sessionID, "completed", task.parentSessionID)
   }
 
   observeSessionDeleted(sessionID: string) {
@@ -345,6 +354,7 @@ class TaskTracker {
       if (task.parentSessionID === sessionID) this.tasks.delete(task.taskID)
     }
     this.latestAssistantBySession.delete(sessionID)
+    this.clearSnapshotIdleForSession(sessionID)
   }
 
   observeMessages(messages: { info?: unknown; role?: unknown; id?: unknown; time?: unknown; parts?: unknown[] }[]) {
@@ -360,7 +370,7 @@ class TaskTracker {
         const status = parseTaskStatus(textFromPart(part))
         if (!status) continue
         if (status.state === "running") this.markRunning(sessionID, status.taskID)
-        else this.markTerminal(status.taskID, status.state)
+        else this.markTerminal(status.taskID, status.state, sessionID, { resetReconciled: true })
       }
     }
   }
@@ -374,11 +384,25 @@ class TaskTracker {
   }
 
   hasBlockingTasks(parentSessionID: string) {
+    this.pruneExpiredSnapshotIdleHolds()
     for (const task of this.tasks.values()) {
       if (task.parentSessionID !== parentSessionID) continue
       if (task.state === "running" || task.terminalUnreconciled) return true
     }
+    for (const hold of this.snapshotIdleHolds.values()) {
+      if (hold.parentSessionID === parentSessionID) return true
+    }
     return false
+  }
+
+  nextSnapshotIdleRetryAt(parentSessionID: string) {
+    this.pruneExpiredSnapshotIdleHolds()
+    let next: number | null = null
+    for (const hold of this.snapshotIdleHolds.values()) {
+      if (hold.parentSessionID !== parentSessionID) continue
+      next = next == null ? hold.expiresAt : Math.min(next, hold.expiresAt)
+    }
+    return next
   }
 
   async refreshLiveChildren(client: Parameters<Plugin>[0]["client"], parentSessionID: string) {
@@ -407,12 +431,16 @@ class TaskTracker {
       const status = statuses[childID]
       const statusType = isRecord(status) && typeof status.type === "string" ? status.type : undefined
       if (statusType === "busy") this.markRunning(parentSessionID, childID)
-      else if (statusType === "idle" && this.tasks.has(childID)) this.markTerminal(childID, "completed")
+      else if (statusType === "idle") {
+        if (this.tasks.has(childID)) this.markTerminal(childID, "completed", parentSessionID)
+        else this.markSnapshotIdle(parentSessionID, childID)
+      }
     }
   }
 
   private markRunning(parentSessionID: string, taskID: string) {
     const existing = this.tasks.get(taskID)
+    this.clearSnapshotIdle(parentSessionID, taskID)
     this.tasks.set(taskID, {
       taskID,
       parentSessionID,
@@ -423,17 +451,72 @@ class TaskTracker {
     })
   }
 
-  private markTerminal(taskID: string, state: TaskState) {
+  private markTerminal(
+    taskID: string,
+    state: TaskState,
+    parentSessionID?: string,
+    options: { resetReconciled?: boolean } = {},
+  ) {
     if (!TASK_TERMINAL_STATES.has(state)) return
     const existing = this.tasks.get(taskID)
-    if (!existing) return
+    const resolvedParentSessionID = existing?.parentSessionID ?? parentSessionID
+    if (!resolvedParentSessionID) return
+    this.clearSnapshotIdle(resolvedParentSessionID, taskID)
+    if (
+      existing &&
+      TASK_TERMINAL_STATES.has(existing.state) &&
+      !existing.terminalUnreconciled &&
+      !options.resetReconciled
+    ) {
+      return
+    }
     this.tasks.set(taskID, {
-      ...existing,
+      taskID,
+      parentSessionID: resolvedParentSessionID,
       state,
       terminalUnreconciled: true,
       terminalAt: Date.now(),
-      lastAssistantMessageIDAtTerminal: this.latestAssistantBySession.get(existing.parentSessionID)?.id ?? null,
+      lastAssistantMessageIDAtTerminal: this.latestAssistantBySession.get(resolvedParentSessionID)?.id ?? null,
     })
+  }
+
+  private markSnapshotIdle(parentSessionID: string, taskID: string) {
+    const key = this.snapshotIdleKey(parentSessionID, taskID)
+    if (this.settledSnapshotIdleTasks.has(key) || this.snapshotIdleHolds.has(key)) return
+    this.snapshotIdleHolds.set(key, {
+      taskID,
+      parentSessionID,
+      expiresAt: Date.now() + SNAPSHOT_IDLE_HOLD_MS,
+    })
+  }
+
+  private clearSnapshotIdle(parentSessionID: string, taskID: string) {
+    const key = this.snapshotIdleKey(parentSessionID, taskID)
+    this.snapshotIdleHolds.delete(key)
+    this.settledSnapshotIdleTasks.delete(key)
+  }
+
+  private clearSnapshotIdleForSession(sessionID: string) {
+    for (const [key, hold] of this.snapshotIdleHolds) {
+      if (hold.taskID === sessionID || hold.parentSessionID === sessionID) this.snapshotIdleHolds.delete(key)
+    }
+    for (const key of this.settledSnapshotIdleTasks) {
+      if (key.startsWith(`${sessionID}\0`) || key.endsWith(`\0${sessionID}`)) {
+        this.settledSnapshotIdleTasks.delete(key)
+      }
+    }
+  }
+
+  private pruneExpiredSnapshotIdleHolds(now = Date.now()) {
+    for (const [key, hold] of this.snapshotIdleHolds) {
+      if (hold.expiresAt > now) continue
+      this.snapshotIdleHolds.delete(key)
+      this.settledSnapshotIdleTasks.add(key)
+    }
+  }
+
+  private snapshotIdleKey(parentSessionID: string, taskID: string) {
+    return `${parentSessionID}\0${taskID}`
   }
 
   private observeAssistant(sessionID: string, marker: AssistantMarker) {
@@ -489,35 +572,43 @@ const server: Plugin = async ({ client }, options?: Options) => {
   const taskTracker = new TaskTracker()
   const taskDeferredSessions = new Set<string>()
   const scheduledContinuations = new Map<string, ReturnType<typeof setTimeout>>()
+  const busySessions = new Set<string>()
 
-  async function tasksBlockContinuation(sessionID: string) {
+  async function taskBlockStatus(sessionID: string) {
     if (!deferWhileTasksActive) return false
     await taskTracker.refreshLiveChildren(client, sessionID)
-    return taskTracker.hasBlockingTasks(sessionID)
+    return {
+      blocked: taskTracker.hasBlockingTasks(sessionID),
+      retryAt: taskTracker.nextSnapshotIdleRetryAt(sessionID),
+    }
   }
 
-  function scheduleSettledContinuation(sessionID: string) {
+  function scheduleSettledContinuation(sessionID: string, delayMs = TASK_SETTLE_DELAY_MS) {
     if (scheduledContinuations.has(sessionID)) return
     const timer = setTimeout(() => {
       scheduledContinuations.delete(sessionID)
       void runAutoContinue(sessionID, true)
-    }, TASK_SETTLE_DELAY_MS)
+    }, Math.max(0, delayMs))
     const maybeUnref = timer as { unref?: () => void }
     if (typeof maybeUnref.unref === "function") maybeUnref.unref()
     scheduledContinuations.set(sessionID, timer)
   }
 
   async function runAutoContinue(sessionID: string, fromTaskDeferral = false) {
+    if (busySessions.has(sessionID)) return
     if (activeContinuations.has(sessionID)) return
     activeContinuations.add(sessionID)
     try {
       const latestAssistant = await fetchLatestAssistant(client, sessionID)
       taskTracker.observeAssistantMessage(sessionID, latestAssistant)
-      await recordAssistantMessage(sessionID, latestAssistant, options ?? {})
-      if (await tasksBlockContinuation(sessionID)) {
+      const taskStatus = await taskBlockStatus(sessionID)
+      if (taskStatus && taskStatus.blocked) {
         taskDeferredSessions.add(sessionID)
+        if (taskStatus.retryAt != null) scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now())
         return
       }
+      if (busySessions.has(sessionID)) return
+      await recordAssistantMessage(sessionID, latestAssistant, options ?? {})
       if (!fromTaskDeferral && taskDeferredSessions.has(sessionID)) {
         scheduleSettledContinuation(sessionID)
         return
@@ -712,10 +803,20 @@ const server: Plugin = async ({ client }, options?: Options) => {
       }
       if (sessionID && eventType === "session.status") {
         const status = (event as { properties?: Record<string, unknown> }).properties?.status
-        if (isRecord(status) && typeof status.type === "string") taskTracker.observeSessionStatus(sessionID, status.type)
+        if (isRecord(status) && typeof status.type === "string") {
+          if (status.type === "busy") busySessions.add(sessionID)
+          if (status.type === "idle") busySessions.delete(sessionID)
+          taskTracker.observeSessionStatus(sessionID, status.type)
+        }
       }
-      if (sessionID && eventType === "session.idle") taskTracker.observeSessionStatus(sessionID, "idle")
-      if (sessionID && eventType === "session.deleted") taskTracker.observeSessionDeleted(sessionID)
+      if (sessionID && eventType === "session.idle") {
+        busySessions.delete(sessionID)
+        taskTracker.observeSessionStatus(sessionID, "idle")
+      }
+      if (sessionID && eventType === "session.deleted") {
+        busySessions.delete(sessionID)
+        taskTracker.observeSessionDeleted(sessionID)
+      }
       if (sessionID && (event as { type?: string }).type === "message.updated") {
         const props = (event as { properties?: Record<string, unknown> }).properties ?? {}
         const message = [props.info, props.message].find((value) => value && typeof value === "object") as

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { compactionContext, continuationPrompt, limitPrompt, systemReminder } fr
 
 type Options = {
   auto_continue?: boolean
+  defer_while_tasks_active?: boolean
   max_auto_turns?: number
   min_continue_interval_seconds?: number
   max_prompt_failures?: number
@@ -54,7 +55,30 @@ const DEFAULT_CONTINUE_INTERVAL_SECONDS = 3
 const DEFAULT_MAX_PROMPT_FAILURES = 3
 const DEFAULT_COMMAND_NAME = "goal"
 const GOAL_SYSTEM_MARKER = "OpenCode goal mode"
+const TASK_SETTLE_DELAY_MS = 25
+const TASK_TERMINAL_STATES = new Set<TaskState>(["completed", "error", "cancelled"])
 const activeContinuations = new Set<string>()
+
+type TaskState = "running" | "completed" | "error" | "cancelled"
+
+type TaskStatus = {
+  taskID: string
+  state: TaskState
+}
+
+type AssistantMarker = {
+  id: string | null
+  completedAt: number | null
+}
+
+type TaskRecord = {
+  taskID: string
+  parentSessionID: string
+  state: TaskState
+  terminalUnreconciled: boolean
+  terminalAt: number | null
+  lastAssistantMessageIDAtTerminal: string | null
+}
 
 function goalCommandTemplate(commandName: string) {
   return `OpenCode goal mode command "/${commandName}" was invoked.
@@ -111,6 +135,16 @@ function textFromMessage(message: { parts?: unknown[] }) {
   return (message.parts ?? []).map(textFromPart).filter(Boolean).join("\n").trim()
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function sessionIDFromMessage(message: { info?: unknown; sessionID?: unknown }) {
+  if (typeof message.sessionID === "string") return message.sessionID
+  if (isRecord(message.info) && typeof message.info.sessionID === "string") return message.info.sessionID
+  return undefined
+}
+
 function estimateMessages(messages: { parts?: unknown[] }[]) {
   return messages.reduce<number>((sum, message) => sum + estimateTokensFromText(textFromMessage(message)), 0)
 }
@@ -159,6 +193,53 @@ function outputTokensFromMessage(message: { info?: unknown; parts?: unknown[] })
 function tokensFromMessages(messages: { info?: unknown; parts?: unknown[] }[]) {
   const exactTotal = messages.reduce<number>((sum, message) => sum + (exactTokensFromMessage(message) ?? 0), 0)
   return exactTotal > 0 ? exactTotal : estimateMessages(messages)
+}
+
+function taskHeader(output: string) {
+  const resultIndex = output.search(/<task_(?:result|error)>/)
+  return resultIndex === -1 ? output : output.slice(0, resultIndex)
+}
+
+function parseTaskID(output: string) {
+  const xmlMatch = /<task\s+[^>]*\bid=["']([^"']+)["'][^>]*>/i.exec(output)
+  if (xmlMatch?.[1]) return xmlMatch[1]
+  for (const line of output.split(/\r?\n/)) {
+    const match = /^task_id:\s*([^\s()]+)(?:\s*\(.*)?$/i.exec(line.trim())
+    if (match?.[1]) return match[1]
+  }
+  return undefined
+}
+
+function parseTaskState(output: string): TaskState | undefined {
+  const xmlMatch = /<task\s+[^>]*\bstate=["'](running|completed|error|cancelled)["'][^>]*>/i.exec(output)
+  if (xmlMatch?.[1]) return xmlMatch[1].toLowerCase() as TaskState
+  for (const line of taskHeader(output).split(/\r?\n/)) {
+    const match = /^state:\s*(running|completed|error|cancelled)\s*$/i.exec(line.trim())
+    if (match?.[1]) return match[1].toLowerCase() as TaskState
+  }
+  return undefined
+}
+
+function parseTaskStatus(output: unknown): TaskStatus | undefined {
+  if (typeof output !== "string") return undefined
+  const taskID = parseTaskID(output)
+  const state = parseTaskState(output)
+  return taskID && state ? { taskID, state } : undefined
+}
+
+function messageCompletedAt(message: { info?: unknown; time?: unknown }) {
+  const time =
+    isRecord(message.time) ? message.time : isRecord(message.info) && isRecord(message.info.time) ? message.info.time : undefined
+  const completed = time?.completed
+  return typeof completed === "number" && Number.isFinite(completed) ? completed : null
+}
+
+function assistantMarker(message: { info?: unknown; role?: unknown; id?: unknown; time?: unknown }): AssistantMarker | undefined {
+  if (messageRole(message) !== "assistant") return undefined
+  return {
+    id: messageID(message) ?? null,
+    completedAt: messageCompletedAt(message),
+  }
 }
 
 async function sendContinuation(client: Parameters<Plugin>[0]["client"], sessionID: string, prompt: string) {
@@ -216,6 +297,162 @@ async function fetchLatestAssistant(client: Parameters<Plugin>[0]["client"], ses
   return latestAssistantMessage(data as { info?: unknown; role?: unknown; id?: unknown; parts?: unknown[] }[])
 }
 
+class TaskTracker {
+  private readonly tasks = new Map<string, TaskRecord>()
+  private readonly pendingTaskCalls = new Map<string, string>()
+  private readonly latestAssistantBySession = new Map<string, AssistantMarker>()
+
+  noteTaskCall(input: { tool?: unknown; sessionID?: unknown; callID?: unknown }) {
+    if (typeof input.tool !== "string" || input.tool.toLowerCase() !== "task") return
+    if (typeof input.sessionID !== "string") return
+    if (typeof input.callID === "string") this.pendingTaskCalls.set(input.callID, input.sessionID)
+  }
+
+  noteTaskOutput(input: { tool?: unknown; sessionID?: unknown; callID?: unknown }, output: { output?: unknown }) {
+    if (typeof input.tool !== "string" || input.tool.toLowerCase() !== "task") return
+    const parentSessionID =
+      typeof input.callID === "string" ? this.pendingTaskCalls.get(input.callID) ?? input.sessionID : input.sessionID
+    if (typeof input.callID === "string") this.pendingTaskCalls.delete(input.callID)
+    if (typeof parentSessionID !== "string") return
+    const status = parseTaskStatus(output.output)
+    if (!status) return
+    if (status.state === "running") {
+      this.markRunning(parentSessionID, status.taskID)
+      return
+    }
+    this.markTerminal(status.taskID, status.state)
+  }
+
+  observeSessionCreated(event: { properties?: Record<string, unknown> }) {
+    const info = event.properties?.info
+    if (!isRecord(info) || typeof info.id !== "string" || typeof info.parentID !== "string") return
+    this.markRunning(info.parentID, info.id)
+  }
+
+  observeSessionStatus(sessionID: string, status: string) {
+    const task = this.tasks.get(sessionID)
+    if (!task) return
+    if (status === "busy") {
+      this.markRunning(task.parentSessionID, sessionID)
+      return
+    }
+    if (status === "idle") this.markTerminal(sessionID, "completed")
+  }
+
+  observeSessionDeleted(sessionID: string) {
+    this.tasks.delete(sessionID)
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionID === sessionID) this.tasks.delete(task.taskID)
+    }
+    this.latestAssistantBySession.delete(sessionID)
+  }
+
+  observeMessages(messages: { info?: unknown; role?: unknown; id?: unknown; time?: unknown; parts?: unknown[] }[]) {
+    for (const message of messages) {
+      const sessionID = sessionIDFromMessage(message)
+      if (!sessionID) continue
+      const marker = assistantMarker(message)
+      if (marker) {
+        this.observeAssistant(sessionID, marker)
+        continue
+      }
+      for (const part of message.parts ?? []) {
+        const status = parseTaskStatus(textFromPart(part))
+        if (!status) continue
+        if (status.state === "running") this.markRunning(sessionID, status.taskID)
+        else this.markTerminal(status.taskID, status.state)
+      }
+    }
+  }
+
+  observeAssistantMessage(
+    sessionID: string,
+    message: { info?: unknown; role?: unknown; id?: unknown; time?: unknown } | undefined,
+  ) {
+    const marker = message ? assistantMarker(message) : undefined
+    if (marker) this.observeAssistant(sessionID, marker)
+  }
+
+  hasBlockingTasks(parentSessionID: string) {
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionID !== parentSessionID) continue
+      if (task.state === "running" || task.terminalUnreconciled) return true
+    }
+    return false
+  }
+
+  async refreshLiveChildren(client: Parameters<Plugin>[0]["client"], parentSessionID: string) {
+    const session = client.session as unknown as {
+      children?: (input: { path: { id: string } }) => Promise<{ data?: unknown } | unknown[]>
+      status?: () => Promise<{ data?: unknown } | Record<string, unknown>>
+    }
+    if (!session.children || !session.status) return
+    let childIDs: string[]
+    try {
+      const result = await session.children({ path: { id: parentSessionID } })
+      const data = Array.isArray(result) ? result : Array.isArray(result.data) ? result.data : []
+      childIDs = data.flatMap((child) => (isRecord(child) && typeof child.id === "string" ? [child.id] : []))
+    } catch {
+      return
+    }
+    if (childIDs.length === 0) return
+    let statuses: Record<string, unknown>
+    try {
+      const result = await session.status()
+      statuses = isRecord(result) && isRecord(result.data) ? result.data : isRecord(result) ? result : {}
+    } catch {
+      return
+    }
+    for (const childID of childIDs) {
+      const status = statuses[childID]
+      const statusType = isRecord(status) && typeof status.type === "string" ? status.type : undefined
+      if (statusType === "busy") this.markRunning(parentSessionID, childID)
+      else if (statusType === "idle" && this.tasks.has(childID)) this.markTerminal(childID, "completed")
+    }
+  }
+
+  private markRunning(parentSessionID: string, taskID: string) {
+    const existing = this.tasks.get(taskID)
+    this.tasks.set(taskID, {
+      taskID,
+      parentSessionID,
+      state: "running",
+      terminalUnreconciled: false,
+      terminalAt: null,
+      lastAssistantMessageIDAtTerminal: existing?.lastAssistantMessageIDAtTerminal ?? null,
+    })
+  }
+
+  private markTerminal(taskID: string, state: TaskState) {
+    if (!TASK_TERMINAL_STATES.has(state)) return
+    const existing = this.tasks.get(taskID)
+    if (!existing) return
+    this.tasks.set(taskID, {
+      ...existing,
+      state,
+      terminalUnreconciled: true,
+      terminalAt: Date.now(),
+      lastAssistantMessageIDAtTerminal: this.latestAssistantBySession.get(existing.parentSessionID)?.id ?? null,
+    })
+  }
+
+  private observeAssistant(sessionID: string, marker: AssistantMarker) {
+    this.latestAssistantBySession.set(sessionID, marker)
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionID !== sessionID || !task.terminalUnreconciled) continue
+      if (this.assistantReconcilesTask(task, marker)) {
+        this.tasks.set(task.taskID, { ...task, terminalUnreconciled: false })
+      }
+    }
+  }
+
+  private assistantReconcilesTask(task: TaskRecord, marker: AssistantMarker) {
+    if (marker.id && task.lastAssistantMessageIDAtTerminal && marker.id !== task.lastAssistantMessageIDAtTerminal) return true
+    if (marker.completedAt != null && task.terminalAt != null && marker.completedAt >= task.terminalAt) return true
+    return false
+  }
+}
+
 async function recordAssistantMessage(
   sessionID: string,
   message: { info?: unknown; role?: unknown; id?: unknown; parts?: unknown[] } | undefined,
@@ -243,13 +480,73 @@ function mergeSystemReminder(output: { system: string[] }, reminder: string) {
 
 const server: Plugin = async ({ client }, options?: Options) => {
   const autoContinue = options?.auto_continue ?? true
+  const deferWhileTasksActive = options?.defer_while_tasks_active ?? true
   const maxAutoTurns = positiveIntegerOrNull(options?.max_auto_turns) ?? DEFAULT_MAX_AUTO_TURNS
   const minInterval = positiveIntegerOrNull(options?.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS
   const maxPromptFailures = positiveIntegerOrNull(options?.max_prompt_failures) ?? DEFAULT_MAX_PROMPT_FAILURES
   const registerCommand = options?.register_command ?? true
   const commandName = commandNameFromOptions(options)
+  const taskTracker = new TaskTracker()
+  const taskDeferredSessions = new Set<string>()
+  const scheduledContinuations = new Map<string, ReturnType<typeof setTimeout>>()
+
+  async function tasksBlockContinuation(sessionID: string) {
+    if (!deferWhileTasksActive) return false
+    await taskTracker.refreshLiveChildren(client, sessionID)
+    return taskTracker.hasBlockingTasks(sessionID)
+  }
+
+  function scheduleSettledContinuation(sessionID: string) {
+    if (scheduledContinuations.has(sessionID)) return
+    const timer = setTimeout(() => {
+      scheduledContinuations.delete(sessionID)
+      void runAutoContinue(sessionID, true)
+    }, TASK_SETTLE_DELAY_MS)
+    const maybeUnref = timer as { unref?: () => void }
+    if (typeof maybeUnref.unref === "function") maybeUnref.unref()
+    scheduledContinuations.set(sessionID, timer)
+  }
+
+  async function runAutoContinue(sessionID: string, fromTaskDeferral = false) {
+    if (activeContinuations.has(sessionID)) return
+    activeContinuations.add(sessionID)
+    try {
+      const latestAssistant = await fetchLatestAssistant(client, sessionID)
+      taskTracker.observeAssistantMessage(sessionID, latestAssistant)
+      await recordAssistantMessage(sessionID, latestAssistant, options ?? {})
+      if (await tasksBlockContinuation(sessionID)) {
+        taskDeferredSessions.add(sessionID)
+        return
+      }
+      if (!fromTaskDeferral && taskDeferredSessions.has(sessionID)) {
+        scheduleSettledContinuation(sessionID)
+        return
+      }
+      taskDeferredSessions.delete(sessionID)
+      const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval)
+      if (!goal) return
+      await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal))
+      await recordContinuationResult(sessionID, "success", maxPromptFailures)
+    } catch (error) {
+      await recordContinuationResult(sessionID, "failure", maxPromptFailures)
+      await client.app?.log?.({
+        body: {
+          service: "opencode-goal-plugin",
+          level: "error",
+          message: "Auto-continue failed",
+          extra: { error: error instanceof Error ? error.message : String(error) },
+        },
+      })
+    } finally {
+      activeContinuations.delete(sessionID)
+    }
+  }
 
   return {
+    async dispose() {
+      for (const timer of scheduledContinuations.values()) clearTimeout(timer)
+      scheduledContinuations.clear()
+    },
     async config(config) {
       if (!registerCommand) return
       registerDesktopCommand(config, commandName)
@@ -375,7 +672,17 @@ const server: Plugin = async ({ client }, options?: Options) => {
         },
       },
     },
+    async "tool.execute.before"(input) {
+      taskTracker.noteTaskCall(input as { tool?: unknown; sessionID?: unknown; callID?: unknown })
+    },
+    async "tool.execute.after"(input, output) {
+      taskTracker.noteTaskOutput(
+        input as { tool?: unknown; sessionID?: unknown; callID?: unknown },
+        output as { output?: unknown },
+      )
+    },
     async "experimental.chat.messages.transform"(input, output) {
+      taskTracker.observeMessages(output.messages)
       const sessionID =
         "sessionID" in input && typeof input.sessionID === "string"
           ? input.sessionID
@@ -399,37 +706,28 @@ const server: Plugin = async ({ client }, options?: Options) => {
     },
     async event({ event }) {
       const sessionID = sessionIDFromEvent(event as never)
+      const eventType = (event as { type?: string }).type
+      if (eventType === "session.created") {
+        taskTracker.observeSessionCreated(event as { properties?: Record<string, unknown> })
+      }
+      if (sessionID && eventType === "session.status") {
+        const status = (event as { properties?: Record<string, unknown> }).properties?.status
+        if (isRecord(status) && typeof status.type === "string") taskTracker.observeSessionStatus(sessionID, status.type)
+      }
+      if (sessionID && eventType === "session.idle") taskTracker.observeSessionStatus(sessionID, "idle")
+      if (sessionID && eventType === "session.deleted") taskTracker.observeSessionDeleted(sessionID)
       if (sessionID && (event as { type?: string }).type === "message.updated") {
         const props = (event as { properties?: Record<string, unknown> }).properties ?? {}
         const message = [props.info, props.message].find((value) => value && typeof value === "object") as
-          | { info?: unknown; role?: unknown; id?: unknown; parts?: unknown[] }
+          | { info?: unknown; role?: unknown; id?: unknown; time?: unknown; parts?: unknown[] }
           | undefined
+        taskTracker.observeAssistantMessage(sessionID, message)
         await recordAssistantMessage(sessionID, message, options ?? {})
       }
 
       if (!autoContinue || !isIdleEvent(event as never)) return
       if (!sessionID) return
-      if (activeContinuations.has(sessionID)) return
-      activeContinuations.add(sessionID)
-      try {
-        await recordAssistantMessage(sessionID, await fetchLatestAssistant(client, sessionID), options ?? {})
-        const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval)
-        if (!goal) return
-        await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal))
-        await recordContinuationResult(sessionID, "success", maxPromptFailures)
-      } catch (error) {
-        await recordContinuationResult(sessionID, "failure", maxPromptFailures)
-        await client.app?.log?.({
-          body: {
-            service: "opencode-goal-plugin",
-            level: "error",
-            message: "Auto-continue failed",
-            extra: { error: error instanceof Error ? error.message : String(error) },
-          },
-        })
-      } finally {
-        activeContinuations.delete(sessionID)
-      }
+      await runAutoContinue(sessionID)
     },
   }
 }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -18,6 +18,11 @@ async function waitFor(predicate: () => boolean) {
   expect(predicate()).toBe(true)
 }
 
+async function waitForContinuation(calls: unknown[]) {
+  await waitFor(() => calls.length === 1)
+  await new Promise((resolve) => setTimeout(resolve, 10))
+}
+
 let dir = ""
 
 beforeEach(async () => {
@@ -467,6 +472,51 @@ test("running task defers idle auto-continue", async () => {
   expect(calls).toHaveLength(0)
 })
 
+test("running task deferral does not record repeated assistant messages as no-progress", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          messages: async () => ({
+            data: [
+              {
+                id: "msg_waiting",
+                role: "assistant",
+                time: { completed: Date.now() },
+                info: { id: "msg_waiting", role: "assistant", sessionID: "ses_1" },
+                parts: [{ type: "text", text: "Waiting for the background task." }],
+              },
+            ],
+          }),
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 3, min_continue_interval_seconds: 0, no_progress_token_threshold: 50 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks["tool.execute.after"]?.(
+    { tool: "Task", sessionID: "ses_1", callID: "call_1", args: {} } as never,
+    { title: "Task", output: "task_id: task_1\nstate: running", metadata: {} } as never,
+  )
+
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(calls).toHaveLength(0)
+  expect(String(read)).toContain('"status": "active"')
+  expect(String(read)).toContain('"autoTurns": 0')
+  expect(String(read)).toContain('"noProgressTurns": 0')
+})
+
 test("terminal task waits for orchestrator assistant turn before goal continuation", async () => {
   const calls: unknown[] = []
   const hooks = await plugin.server(
@@ -508,7 +558,60 @@ test("terminal task waits for orchestrator assistant turn before goal continuati
   })
   await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
 
-  await waitFor(() => calls.length === 1)
+  await waitForContinuation(calls)
+  expect(JSON.stringify(calls[0])).toContain("Continue working toward the active session goal")
+})
+
+test("terminal-only task output defers until orchestrator reconciles it", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 1, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks["tool.execute.before"]?.(
+    { tool: "Task", sessionID: "ses_1", callID: "call_1" } as never,
+    { args: { subagent_type: "fixer", background: true } } as never,
+  )
+  await hooks["tool.execute.after"]?.(
+    { tool: "Task", sessionID: "ses_1", callID: "call_1", args: {} } as never,
+    {
+      title: "Task",
+      output: "task_id: task_1\nstate: completed\n\n<task_result>\ndone\n</task_result>",
+      metadata: {},
+    } as never,
+  )
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(0)
+
+  await hooks.event!({
+    event: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg_after_terminal_only_task",
+          role: "assistant",
+          sessionID: "ses_1",
+          time: { created: Date.now(), completed: Date.now() + 1 },
+        },
+      },
+    } as never,
+  })
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  await waitForContinuation(calls)
   expect(JSON.stringify(calls[0])).toContain("Continue working toward the active session goal")
 })
 
@@ -573,6 +676,68 @@ test("live child session status blocks goal continuation when task launch was mi
   await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
 
   expect(calls).toHaveLength(0)
+})
+
+test("idle live child session uses bounded deferral when task launch was missed", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          children: async () => ({ data: [{ id: "task_1" }] }),
+          status: async () => ({ data: { task_1: { type: "idle" } } }),
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 1, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(0)
+  await waitForContinuation(calls)
+  expect(JSON.stringify(calls[0])).toContain("Continue working toward the active session goal")
+})
+
+test("idle live child bounded retry does not inject while parent session is busy", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          children: async () => ({ data: [{ id: "task_1" }] }),
+          status: async () => ({ data: { task_1: { type: "idle" } } }),
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 1, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 300))
+
+  expect(calls).toHaveLength(0)
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "idle" } } } as never,
+  })
+
+  await waitForContinuation(calls)
+  expect(JSON.stringify(calls[0])).toContain("Continue working toward the active session goal")
 })
 
 test("task deferral can be disabled with config", async () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -9,6 +9,15 @@ function requireTool<T>(tool: T | undefined, name: string): T {
   return tool
 }
 
+async function waitFor(predicate: () => boolean) {
+  const deadline = Date.now() + 500
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  expect(predicate()).toBe(true)
+}
+
 let dir = ""
 
 beforeEach(async () => {
@@ -423,6 +432,172 @@ test("session status idle event auto-continues active goals", async () => {
 
   await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
   await hooks.event!({ event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "idle" } } } as never })
+
+  expect(calls).toHaveLength(1)
+})
+
+test("running task defers idle auto-continue", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 1, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks["tool.execute.before"]?.(
+    { tool: "Task", sessionID: "ses_1", callID: "call_1" } as never,
+    { args: { subagent_type: "fixer", background: true } } as never,
+  )
+  await hooks["tool.execute.after"]?.(
+    { tool: "Task", sessionID: "ses_1", callID: "call_1", args: {} } as never,
+    { title: "Task", output: "task_id: task_1\nstate: running", metadata: {} } as never,
+  )
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(0)
+})
+
+test("terminal task waits for orchestrator assistant turn before goal continuation", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 1, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks["tool.execute.after"]?.(
+    { tool: "Task", sessionID: "ses_1", callID: "call_1", args: {} } as never,
+    { title: "Task", output: "task_id: task_1\nstate: running", metadata: {} } as never,
+  )
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "task_1" } } as never })
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  expect(calls).toHaveLength(0)
+
+  await hooks.event!({
+    event: {
+      type: "message.updated",
+      properties: {
+        info: {
+          id: "msg_after_task",
+          role: "assistant",
+          sessionID: "ses_1",
+          time: { created: Date.now(), completed: Date.now() + 1 },
+        },
+      },
+    } as never,
+  })
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  await waitFor(() => calls.length === 1)
+  expect(JSON.stringify(calls[0])).toContain("Continue working toward the active session goal")
+})
+
+test("synthetic terminal task message defers until orchestrator reconciles it", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 1, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks["tool.execute.after"]?.(
+    { tool: "Task", sessionID: "ses_1", callID: "call_1", args: {} } as never,
+    { title: "Task", output: '<task id="task_1" state="running"></task>', metadata: {} } as never,
+  )
+  await hooks["experimental.chat.messages.transform"]!(
+    {},
+    {
+      messages: [
+        {
+          info: { id: "msg_task_done", role: "user", sessionID: "ses_1", agent: "orchestrator" },
+          parts: [{ type: "text", synthetic: true, text: "task_id: task_1\nstate: completed\n\n<task_result>\ndone\n</task_result>" }],
+        },
+      ],
+    } as never,
+  )
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(0)
+})
+
+test("live child session status blocks goal continuation when task launch was missed", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          children: async () => ({ data: [{ id: "task_1" }] }),
+          status: async () => ({ data: { task_1: { type: "busy" } } }),
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 1, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(0)
+})
+
+test("task deferral can be disabled with config", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, defer_while_tasks_active: false, max_auto_turns: 1, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks["tool.execute.after"]?.(
+    { tool: "Task", sessionID: "ses_1", callID: "call_1", args: {} } as never,
+    { title: "Task", output: "task_id: task_1\nstate: running", metadata: {} } as never,
+  )
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
 
   expect(calls).toHaveLength(1)
 })


### PR DESCRIPTION
## Summary
- add `defer_while_tasks_active`, enabled by default, so goal auto-continuation waits while background `Task` child sessions are still active
- defer again after a task reaches a terminal state until the parent/orchestrator assistant turn has reconciled the result
- discover task activity from Task tool output, session events, message transforms, and live child-session status refreshes
- document the new option and behavior

## Problem
This issue came from `oh-my-opencode-slim` creating background agents. While a background subagent was still running, this plugin could keep injecting goal continuation prompts into the parent session. The main agent would repeatedly answer that it was waiting for the subagent to complete, so the loop did no useful work.

That is both noisy and wasteful: in the old auto-continue path, each idle event reserved a continuation before sending the prompt, and `reserveContinuation` increments `autoTurns` immediately. So these waiting-only loops could burn the goal continuation count, consume tokens, and push the goal toward `max_auto_turns` without making progress.

## Implementation
The fix is implemented at the OpenCode `Task` child-session level, so it is not specific to `oh-my-opencode-slim`. It supports all OpenCode background tasks/subagents that surface as background `Task` child sessions.

The task-blocking check now happens before `reserveContinuation`, so deferring while a background task is still running does not count as a goal continuation attempt.

## Tests
- `bun test`
- Manual smoke-tested with the modified plugin and `oh-my-opencode-slim`; goal continuation was not injected while a background subagent was running.
- Manual prompt tested: `/goal ping all agents in the background one by one, each wait for 20 seconds to return. stop after each ping but don't pause the goal.` Continuation did not trigger during background waiting, and did trigger after the background work actually stopped.