### PR TITLE
fix: prune missing task sessions

### DIFF
--- a/dist/server.js
+++ b/dist/server.js
@@ -1144,7 +1144,7 @@ class TaskTracker {
   }
   async refreshLiveChildren(client, parentSessionID) {
     const session = client.session;
-    if (!session.children || !session.status)
+    if (!session.children)
       return;
     let childIDs;
     try {
@@ -1154,7 +1154,8 @@ class TaskTracker {
     } catch {
       return;
     }
-    if (childIDs.length === 0)
+    this.markAbsentRunningChildren(parentSessionID, new Set(childIDs));
+    if (childIDs.length === 0 || !session.status)
       return;
     let statuses;
     try {
@@ -1240,6 +1241,16 @@ class TaskTracker {
         continue;
       this.snapshotIdleHolds.delete(key);
       this.settledSnapshotIdleTasks.add(key);
+      const task = this.tasks.get(hold.taskID);
+      if (task?.parentSessionID === hold.parentSessionID && task.state === "running")
+        this.tasks.delete(hold.taskID);
+    }
+  }
+  markAbsentRunningChildren(parentSessionID, liveChildIDs) {
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionID !== parentSessionID || task.state !== "running" || liveChildIDs.has(task.taskID))
+        continue;
+      this.markSnapshotIdle(parentSessionID, task.taskID);
     }
   }
   snapshotIdleKey(parentSessionID, taskID) {

--- a/dist/server.js
+++ b/dist/server.js
@@ -1375,6 +1375,8 @@ var server = async ({ client }, options) => {
           await pauseGoalForPlanMode(sessionID);
         return;
       }
+      if (busySessions.has(sessionID))
+        return;
       if (!fromTaskDeferral && taskDeferredSessions.has(sessionID)) {
         scheduleSettledContinuation(sessionID);
         return;

--- a/src/server.ts
+++ b/src/server.ts
@@ -438,7 +438,7 @@ class TaskTracker {
       children?: (input: { path: { id: string } }) => Promise<{ data?: unknown } | unknown[]>
       status?: () => Promise<{ data?: unknown } | Record<string, unknown>>
     }
-    if (!session.children || !session.status) return
+    if (!session.children) return
     let childIDs: string[]
     try {
       const result = await session.children({ path: { id: parentSessionID } })
@@ -447,7 +447,8 @@ class TaskTracker {
     } catch {
       return
     }
-    if (childIDs.length === 0) return
+    this.markAbsentRunningChildren(parentSessionID, new Set(childIDs))
+    if (childIDs.length === 0 || !session.status) return
     let statuses: Record<string, unknown>
     try {
       const result = await session.status()
@@ -540,6 +541,15 @@ class TaskTracker {
       if (hold.expiresAt > now) continue
       this.snapshotIdleHolds.delete(key)
       this.settledSnapshotIdleTasks.add(key)
+      const task = this.tasks.get(hold.taskID)
+      if (task?.parentSessionID === hold.parentSessionID && task.state === "running") this.tasks.delete(hold.taskID)
+    }
+  }
+
+  private markAbsentRunningChildren(parentSessionID: string, liveChildIDs: Set<string>) {
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionID !== parentSessionID || task.state !== "running" || liveChildIDs.has(task.taskID)) continue
+      this.markSnapshotIdle(parentSessionID, task.taskID)
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -672,6 +672,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
         if (current.status === "active") await pauseGoalForPlanMode(sessionID)
         return
       }
+      if (busySessions.has(sessionID)) return
       if (!fromTaskDeferral && taskDeferredSessions.has(sessionID)) {
         scheduleSettledContinuation(sessionID)
         return

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -839,6 +839,38 @@ test("idle live child bounded retry does not inject while parent session is busy
   expect(JSON.stringify(calls[0])).toContain("Continue working toward the active session goal")
 })
 
+test("tracked running child absent from live children stops blocking after grace period", async () => {
+  const calls: unknown[] = []
+  let children = [{ id: "task_1" }]
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          children: async () => ({ data: children }),
+          status: async () => ({ data: { task_1: { type: "busy" } } }),
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 1, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  expect(calls).toHaveLength(0)
+
+  children = []
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(0)
+  await waitForContinuation(calls)
+  expect(JSON.stringify(calls[0])).toContain("Continue working toward the active session goal")
+})
+
 test("task deferral can be disabled with config", async () => {
   const calls: unknown[] = []
   const hooks = await plugin.server(


### PR DESCRIPTION
## Summary
- retry briefly when a known running child task disappears from live session status
- prune still-missing child tasks as unobservable so they no longer block goal continuation
- write continuation debug logs as per-session JSONL files behind the `debug_log` option, which is disabled by default

## Why
Goal continuation defers while child tasks are active so the parent session does not continue before background agents finish. That is correct while a child task is visibly running, but it can deadlock when OpenCode can no longer observe that child session.

A child task can disappear from status after an interrupt, terminating/restarting OpenCode, moving the session to a different folder, or other session-lifecycle edge cases. In that state the plugin only remembers an old `running` task record, while live status returns missing/null. Since there is no terminal event to reconcile, the old task can block continuation forever.

I hit this during development: a background agent hung, I restarted OpenCode, then asked for goal continuation. The plugin did not recognize that the task had already completed or was gone, so continuation stayed blocked by the stale child task.

This change treats missing live status as unknown/unobservable: wait a short grace period, then prune the stale task record without requiring parent reconciliation.

## Manual test
- Tested this version against a session that did not trigger goal continuation; goal continuation worked

## Validation
- `bun run typecheck`
- `bun test`
- `bun run lint`
- `bun run build`