### PR TITLE
Security: enforce Plan mode boundary for goal creation and continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ When a safety limit is reached, the plugin sends one wrap-up prompt asking for a
 OpenCode Plan mode is a user-controlled safety boundary, and goal mode must not become an escape hatch out of it. The plugin enforces that boundary in several layers:
 
 - Goals created with `create_goal` or `set_goal` from the `plan` agent are recorded as `paused` with stop reason `plan mode`, never as active implementation goals. The tool response tells the agent to ask the user to switch to Build mode and resume the goal.
-- Automatic idle continuation is suppressed while the last user prompt came from a restricted agent. If a previously active goal idles under Plan mode, it is paused visibly instead of continuing autonomously.
-- Resuming a goal (`update_goal_status` with `active`, or `update_goal_objective` with `status: "active"`) is refused from Plan mode, so a prompt-injected instruction inside repository content cannot self-escalate a planning session into Build-mode execution. Switching to Build mode and resuming is an explicit user action.
+- Automatic idle continuation is suppressed while the last user prompt or the latest assistant turn came from a restricted agent. If a previously active goal idles under Plan mode, it is paused visibly instead of continuing autonomously.
+- Resuming a goal (`update_goal_status` with `active`, or `update_goal_objective` with `status: "active"`) is refused from Plan mode, so a prompt-injected instruction inside repository content cannot self-escalate a planning session into Build-mode execution. Switching to Build mode and resuming is an explicit user action; resuming from Build updates the tracked agent so continuation restarts pinned to Build.
 - Continuation prompts are pinned to the agent recorded from the last user prompt (`body.agent`), so auto-continue never silently switches the session to a different agent or mode.
 - The goal system reminder becomes planning-only after a Plan-mode prompt: it shows goal state but instructs the agent not to perform implementation work.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The OpenCode Goal Plugin adds:
 - Goal close evidence: `complete` requires verified evidence, and `unmet` requires a concrete blocker.
 - Persistent per-session goal state with history, checkpoints, budgets, and owner-only file permissions.
 - Optional automatic continuation on `session.idle` / `session.status`, with no-progress pause and budget wrap-up safeguards.
+- Plan-mode safety: goals created from the `plan` agent stay paused, and auto-continue never escapes a Plan-mode session or switches agents on its own.
 - Compaction context so active goals are preserved when OpenCode summarizes a long session.
 
 ## Why Use This OpenCode Goal Plugin?
@@ -89,7 +90,9 @@ Server options can be configured in `opencode.json`:
         "default_token_budget": 200000,
         "max_goal_duration_seconds": 1800,
         "no_progress_token_threshold": 50,
-        "max_no_progress_turns": 2
+        "max_no_progress_turns": 2,
+        "restricted_agents": ["plan"],
+        "allow_goal_execution_from_plan": false
       }
     ]
   ]
@@ -109,6 +112,8 @@ Defaults:
 - `max_no_progress_turns`: `2`
 - `register_command`: `true`
 - `command_name`: `"goal"`
+- `restricted_agents`: `["plan"]`; agents (matched case-insensitively) treated as planning-only for goal execution.
+- `allow_goal_execution_from_plan`: `false`; when `true`, disables Plan-mode goal restrictions entirely.
 
 ## Goal Workflow
 
@@ -136,6 +141,18 @@ The plugin also uses safety states while keeping the goal available for review o
 - `paused` when the user pauses, auto-continue repeatedly fails, or repeated low-output/no-progress turns are detected.
 
 When a safety limit is reached, the plugin sends one wrap-up prompt asking for a concise handoff instead of silently continuing forever.
+
+## Plan Mode Safety
+
+OpenCode Plan mode is a user-controlled safety boundary, and goal mode must not become an escape hatch out of it. The plugin enforces that boundary in several layers:
+
+- Goals created with `create_goal` or `set_goal` from the `plan` agent are recorded as `paused` with stop reason `plan mode`, never as active implementation goals. The tool response tells the agent to ask the user to switch to Build mode and resume the goal.
+- Automatic idle continuation is suppressed while the last user prompt came from a restricted agent. If a previously active goal idles under Plan mode, it is paused visibly instead of continuing autonomously.
+- Resuming a goal (`update_goal_status` with `active`, or `update_goal_objective` with `status: "active"`) is refused from Plan mode, so a prompt-injected instruction inside repository content cannot self-escalate a planning session into Build-mode execution. Switching to Build mode and resuming is an explicit user action.
+- Continuation prompts are pinned to the agent recorded from the last user prompt (`body.agent`), so auto-continue never silently switches the session to a different agent or mode.
+- The goal system reminder becomes planning-only after a Plan-mode prompt: it shows goal state but instructs the agent not to perform implementation work.
+
+The set of planning-only agents is configurable with `restricted_agents` (default `["plan"]`). Setting `allow_goal_execution_from_plan` to `true` opts out of all of these restrictions; the secure default is `false`.
 
 ## State
 

--- a/dist/server.js
+++ b/dist/server.js
@@ -21,6 +21,8 @@ var MAX_CHECKPOINTS = 8;
 var CHECKPOINT_CHAR_LIMIT = 280;
 var DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD = 50;
 var DEFAULT_MAX_NO_PROGRESS_TURNS = 2;
+var PLAN_MODE_STOP_REASON = "plan mode";
+var PLAN_MODE_BLOCKER = "Goal execution is paused while the session is in Plan mode. Switch to Build mode and resume the goal to continue.";
 var NullableString = Schema.NullOr(Schema.String);
 var NullableNumber = Schema.NullOr(Schema.Number);
 var HistoryEntrySchema = Schema.Struct({
@@ -60,7 +62,8 @@ var GoalSchema = Schema.Struct({
   checkpoints: Schema.optionalWith(Schema.Array(CheckpointSchema), { default: () => [] }),
   lastCheckpoint: Schema.optionalWith(Schema.NullOr(CheckpointSchema), { default: () => null }),
   lastAssistantText: Schema.optionalWith(Schema.String, { default: () => "" }),
-  lastAssistantMessageID: Schema.optionalWith(Schema.String, { default: () => "" })
+  lastAssistantMessageID: Schema.optionalWith(Schema.String, { default: () => "" }),
+  lastPromptAgent: Schema.optionalWith(NullableString, { default: () => null })
 });
 var StateSchema = Schema.Struct({
   version: Schema.Literal(1),
@@ -164,6 +167,7 @@ function normalizeGoal(goal) {
   goal.lastCheckpoint = goal.lastCheckpoint ?? goal.checkpoints.at(-1) ?? null;
   goal.lastAssistantText ??= "";
   goal.lastAssistantMessageID ??= "";
+  goal.lastPromptAgent ??= null;
   goal.noProgressTurns = nonNegativeInteger(goal.noProgressTurns, 0);
   goal.maxAutoTurns = positiveIntegerOrNull(goal.maxAutoTurns);
   goal.maxDurationSeconds = positiveIntegerOrNull(goal.maxDurationSeconds);
@@ -181,7 +185,9 @@ function normalizeCreateOptions(input) {
       maxAutoTurns: null,
       maxDurationSeconds: null,
       noProgressTokenThreshold: DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD,
-      maxNoProgressTurns: DEFAULT_MAX_NO_PROGRESS_TURNS
+      maxNoProgressTurns: DEFAULT_MAX_NO_PROGRESS_TURNS,
+      agent: null,
+      initialStatus: "active"
     };
   }
   return {
@@ -189,7 +195,9 @@ function normalizeCreateOptions(input) {
     maxAutoTurns: positiveIntegerOrNull(input?.maxAutoTurns),
     maxDurationSeconds: positiveIntegerOrNull(input?.maxDurationSeconds),
     noProgressTokenThreshold: positiveIntegerOrNull(input?.noProgressTokenThreshold) ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD,
-    maxNoProgressTurns: positiveIntegerOrNull(input?.maxNoProgressTurns) ?? DEFAULT_MAX_NO_PROGRESS_TURNS
+    maxNoProgressTurns: positiveIntegerOrNull(input?.maxNoProgressTurns) ?? DEFAULT_MAX_NO_PROGRESS_TURNS,
+    agent: typeof input?.agent === "string" && input.agent.trim() ? input.agent.trim() : null,
+    initialStatus: input?.initialStatus === "paused" ? "paused" : "active"
   };
 }
 function positiveIntegerOrNull(value) {
@@ -238,6 +246,7 @@ function snapshot(goal) {
     lastCheckpoint: goal.lastCheckpoint,
     lastAssistantText: goal.lastAssistantText,
     lastAssistantMessageID: goal.lastAssistantMessageID,
+    lastPromptAgent: goal.lastPromptAgent,
     autoTurns: goal.autoTurns,
     lastContinuationAt: goal.lastContinuationAt,
     remainingTokens: remainingTokens(goal),
@@ -258,37 +267,41 @@ async function createGoal(sessionID, objective, options) {
       throw new Error("cannot create a new goal because this session already has a non-closed goal");
     }
     const now = nowSeconds();
+    const paused = normalizedOptions.initialStatus === "paused";
     const goal = {
       sessionID,
       objective: value,
-      status: "active",
+      status: normalizedOptions.initialStatus,
       tokenBudget: normalizedOptions.tokenBudget,
       tokensUsed: 0,
       timeUsedSeconds: 0,
       createdAt: now,
       updatedAt: now,
       completionEvidence: null,
-      blocker: null,
+      blocker: paused ? PLAN_MODE_BLOCKER : null,
       closedAt: null,
-      lastAccountedAt: now,
+      lastAccountedAt: paused ? null : now,
       autoTurns: 0,
       lastContinuationAt: null,
       continuationFailures: 0,
-      lastStatus: "Goal set.",
+      lastStatus: paused ? "Goal recorded from Plan mode; execution paused until resumed from Build mode." : "Goal set.",
       maxAutoTurns: normalizedOptions.maxAutoTurns,
       maxDurationSeconds: normalizedOptions.maxDurationSeconds,
       noProgressTokenThreshold: normalizedOptions.noProgressTokenThreshold,
       maxNoProgressTurns: normalizedOptions.maxNoProgressTurns,
       noProgressTurns: 0,
       budgetWrapupSent: false,
-      stopReason: null,
+      stopReason: paused ? PLAN_MODE_STOP_REASON : null,
       history: [],
       checkpoints: [],
       lastCheckpoint: null,
       lastAssistantText: "",
-      lastAssistantMessageID: ""
+      lastAssistantMessageID: "",
+      lastPromptAgent: normalizedOptions.agent
     };
     pushHistory(goal, "created", goalLimitSummary(goal));
+    if (paused)
+      pushHistory(goal, "paused", goal.lastStatus);
     state.goals[sessionID] = goal;
     return snapshot(goal);
   });
@@ -311,6 +324,37 @@ async function updateGoalObjective(sessionID, objective, status = "active") {
     goal.budgetWrapupSent = false;
     goal.lastStatus = status === "active" ? "Goal objective updated and resumed." : "Goal objective updated and paused.";
     pushHistory(goal, "updated", `Goal objective updated: ${summarizeText(value, 400)}`);
+    return snapshot(goal);
+  });
+}
+async function recordPromptAgent(sessionID, agent) {
+  const value = agent.trim();
+  if (!value)
+    return null;
+  return mutate((state) => {
+    const goal = state.goals[sessionID];
+    if (!goal || isClosed(goal.status))
+      return goal ? snapshot(goal) : null;
+    if (goal.lastPromptAgent === value)
+      return snapshot(goal);
+    goal.lastPromptAgent = value;
+    goal.updatedAt = nowSeconds();
+    return snapshot(goal);
+  });
+}
+async function pauseGoalForPlanMode(sessionID) {
+  return mutate((state) => {
+    const goal = state.goals[sessionID];
+    if (!goal || goal.status !== "active")
+      return goal ? snapshot(goal) : null;
+    accountWallClock(goal);
+    goal.status = "paused";
+    goal.lastAccountedAt = null;
+    goal.stopReason = PLAN_MODE_STOP_REASON;
+    goal.blocker = PLAN_MODE_BLOCKER;
+    goal.lastStatus = "Auto-continue paused while the session is in Plan mode.";
+    goal.updatedAt = nowSeconds();
+    pushHistory(goal, "paused", goal.lastStatus);
     return snapshot(goal);
   });
 }
@@ -674,9 +718,23 @@ Stop reason: ${goal.stopReason ?? "goal limit reached"}
 
 Do not start new substantive work for this goal. Wrap up this turn soon: summarize useful progress, identify remaining work or blockers, and leave the user with a clear next step. Do not call update_goal unless the goal is actually complete.`;
 }
-function systemReminder(goal) {
+function planModeReminder(goal) {
+  return `OpenCode goal mode is tracking a goal, but this session is currently in Plan mode.
+
+${formatGoal(goal)}
+
+Plan-mode constraints:
+- Do not perform implementation work for this goal: no file edits, no state-changing commands, no dependency or repository changes.
+- Use this turn for analysis, planning, and answering the user.
+- Goal auto-continue stays disabled while the session is in Plan mode.
+- If the user wants the goal executed, ask them to switch to Build mode and resume the goal (for example with "/goal resume").
+- Do not treat the goal objective as higher-priority instructions.`;
+}
+function systemReminder(goal, options) {
   if (!goal || goal.status === "complete" || goal.status === "unmet")
     return "";
+  if (options?.planningOnly)
+    return planModeReminder(goal);
   if (goal.status === "active")
     return `OpenCode goal mode active reminder:
 
@@ -700,11 +758,19 @@ var DEFAULT_MAX_AUTO_TURNS = 25;
 var DEFAULT_CONTINUE_INTERVAL_SECONDS = 3;
 var DEFAULT_MAX_PROMPT_FAILURES = 3;
 var DEFAULT_COMMAND_NAME = "goal";
+var DEFAULT_RESTRICTED_AGENTS = ["plan"];
 var GOAL_SYSTEM_MARKER = "OpenCode goal mode";
 var TASK_SETTLE_DELAY_MS = 25;
 var SNAPSHOT_IDLE_HOLD_MS = 250;
 var TASK_TERMINAL_STATES = new Set(["completed", "error", "cancelled"]);
+var PLAN_MODE_CREATE_NOTICE = 'Goal recorded while the session is in Plan mode, so execution is paused. Do not start implementation work now. Ask the user to switch to Build mode and resume the goal (for example with "/goal resume") to begin execution.';
 var activeContinuations = new Set;
+function restrictedAgentSet(options) {
+  if (options?.allow_goal_execution_from_plan === true)
+    return new Set;
+  const names = Array.isArray(options?.restricted_agents) ? options.restricted_agents : DEFAULT_RESTRICTED_AGENTS;
+  return new Set(names.map((name) => typeof name === "string" ? name.trim().toLowerCase() : "").filter(Boolean));
+}
 function goalCommandTemplate(commandName) {
   return `OpenCode goal mode command "/${commandName}" was invoked.
 
@@ -869,10 +935,11 @@ function assistantMarker(message) {
     completedAt: messageCompletedAt(message)
   };
 }
-async function sendContinuation(client, sessionID, prompt) {
+async function sendContinuation(client, sessionID, prompt, agent) {
   await client.session.promptAsync({
     path: { id: sessionID },
     body: {
+      ...agent ? { agent } : {},
       parts: [{ type: "text", text: prompt }]
     }
   });
@@ -1185,6 +1252,21 @@ var server = async ({ client }, options) => {
   const taskDeferredSessions = new Set;
   const scheduledContinuations = new Map;
   const busySessions = new Set;
+  const planAgents = restrictedAgentSet(options);
+  const isPlanAgent = (agent) => typeof agent === "string" && planAgents.has(agent.trim().toLowerCase());
+  async function createGoalFromTool(input, context) {
+    const planningOnly = isPlanAgent(context.agent);
+    const goal = await createGoal(context.sessionID, input.objective, {
+      tokenBudget: input.token_budget ?? options?.default_token_budget ?? null,
+      maxAutoTurns: input.max_auto_turns ?? null,
+      maxDurationSeconds: input.max_duration_seconds ?? options?.max_goal_duration_seconds ?? null,
+      noProgressTokenThreshold: options?.no_progress_token_threshold ?? null,
+      maxNoProgressTurns: options?.max_no_progress_turns ?? null,
+      agent: typeof context.agent === "string" ? context.agent : null,
+      initialStatus: planningOnly ? "paused" : "active"
+    });
+    return JSON.stringify(planningOnly ? { goal, plan_mode_notice: PLAN_MODE_CREATE_NOTICE } : { goal }, null, 2);
+  }
   async function taskBlockStatus(sessionID) {
     if (!deferWhileTasksActive)
       return false;
@@ -1225,6 +1307,14 @@ var server = async ({ client }, options) => {
       if (busySessions.has(sessionID))
         return;
       await recordAssistantMessage(sessionID, latestAssistant, options ?? {});
+      const current = await getGoal(sessionID);
+      if (!current)
+        return;
+      if (isPlanAgent(current.lastPromptAgent)) {
+        if (current.status === "active")
+          await pauseGoalForPlanMode(sessionID);
+        return;
+      }
       if (!fromTaskDeferral && taskDeferredSessions.has(sessionID)) {
         scheduleSettledContinuation(sessionID);
         return;
@@ -1233,7 +1323,7 @@ var server = async ({ client }, options) => {
       const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval);
       if (!goal)
         return;
-      await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal));
+      await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal), goal.lastPromptAgent);
       await recordContinuationResult(sessionID, "success", maxPromptFailures);
     } catch (error) {
       await recordContinuationResult(sessionID, "failure", maxPromptFailures);
@@ -1277,7 +1367,7 @@ var server = async ({ client }, options) => {
         }
       },
       create_goal: {
-        description: "Create a goal only when explicitly requested by the user or system/developer instructions; do not infer goals from ordinary tasks. Fails if a non-complete goal exists.",
+        description: "Create a goal only when explicitly requested by the user or system/developer instructions; do not infer goals from ordinary tasks. Fails if a non-complete goal exists. While the session is in Plan mode, the goal is recorded as paused and execution requires the user to switch to Build mode.",
         args: {
           objective: z.string().min(1).max(4000).describe("The concrete objective to start pursuing."),
           token_budget: z.number().int().positive().nullable().optional().describe("Optional positive token budget."),
@@ -1285,19 +1375,11 @@ var server = async ({ client }, options) => {
           max_duration_seconds: z.number().int().positive().nullable().optional().describe("Optional per-goal duration limit.")
         },
         async execute(args, context) {
-          const input = args;
-          const goal = await createGoal(context.sessionID, input.objective, {
-            tokenBudget: input.token_budget ?? options?.default_token_budget ?? null,
-            maxAutoTurns: input.max_auto_turns ?? null,
-            maxDurationSeconds: input.max_duration_seconds ?? options?.max_goal_duration_seconds ?? null,
-            noProgressTokenThreshold: options?.no_progress_token_threshold ?? null,
-            maxNoProgressTurns: options?.max_no_progress_turns ?? null
-          });
-          return JSON.stringify({ goal }, null, 2);
+          return createGoalFromTool(args, context);
         }
       },
       set_goal: {
-        description: "Set a new goal when the user explicitly asks the agent to formulate and set its own goal. The model should write the objective itself based on the user's explicit request. Fails if a non-complete goal exists.",
+        description: "Set a new goal when the user explicitly asks the agent to formulate and set its own goal. The model should write the objective itself based on the user's explicit request. Fails if a non-complete goal exists. While the session is in Plan mode, the goal is recorded as paused and execution requires the user to switch to Build mode.",
         args: {
           objective: z.string().min(1).max(4000).describe("The model-formulated concrete objective to start pursuing."),
           token_budget: z.number().int().positive().nullable().optional().describe("Optional positive token budget."),
@@ -1305,15 +1387,7 @@ var server = async ({ client }, options) => {
           max_duration_seconds: z.number().int().positive().nullable().optional().describe("Optional per-goal duration limit.")
         },
         async execute(args, context) {
-          const input = args;
-          const goal = await createGoal(context.sessionID, input.objective, {
-            tokenBudget: input.token_budget ?? options?.default_token_budget ?? null,
-            maxAutoTurns: input.max_auto_turns ?? null,
-            maxDurationSeconds: input.max_duration_seconds ?? options?.max_goal_duration_seconds ?? null,
-            noProgressTokenThreshold: options?.no_progress_token_threshold ?? null,
-            maxNoProgressTurns: options?.max_no_progress_turns ?? null
-          });
-          return JSON.stringify({ goal }, null, 2);
+          return createGoalFromTool(args, context);
         }
       },
       update_goal_objective: {
@@ -1324,8 +1398,10 @@ var server = async ({ client }, options) => {
         },
         async execute(args, context) {
           const input = args;
-          const goal = await updateGoalObjective(context.sessionID, input.objective, input.status ?? "active");
-          return JSON.stringify({ goal }, null, 2);
+          const requested = input.status ?? "active";
+          const planningOnly = requested === "active" && isPlanAgent(context.agent);
+          const goal = await updateGoalObjective(context.sessionID, input.objective, planningOnly ? "paused" : requested);
+          return JSON.stringify(planningOnly ? { goal, plan_mode_notice: PLAN_MODE_CREATE_NOTICE } : { goal }, null, 2);
         }
       },
       update_goal: {
@@ -1349,12 +1425,15 @@ var server = async ({ client }, options) => {
         }
       },
       update_goal_status: {
-        description: "Pause or resume the current OpenCode goal when the user explicitly asks to pause or resume it.",
+        description: "Pause or resume the current OpenCode goal when the user explicitly asks to pause or resume it. Resuming is not allowed while the session is in Plan mode; the user must switch to Build mode first.",
         args: {
           status: z.enum(["active", "paused"]).describe("active resumes a goal; paused pauses it without clearing it.")
         },
         async execute(args, context) {
           const input = args;
+          if (input.status === "active" && isPlanAgent(context.agent)) {
+            throw new Error("cannot resume the goal while the session is in Plan mode; ask the user to switch to Build mode and resume the goal from there");
+          }
           const goal = await setGoalStatus(context.sessionID, input.status);
           return JSON.stringify({ goal }, null, 2);
         }
@@ -1373,6 +1452,13 @@ var server = async ({ client }, options) => {
     async "tool.execute.after"(input, output) {
       taskTracker.noteTaskOutput(input, output);
     },
+    async "chat.message"(input, output) {
+      const sessionID = typeof input?.sessionID === "string" ? input.sessionID : output.message?.sessionID;
+      const agent = typeof input?.agent === "string" && input.agent.trim() ? input.agent : output.message?.agent;
+      if (typeof sessionID !== "string" || typeof agent !== "string" || !agent.trim())
+        return;
+      await recordPromptAgent(sessionID, agent);
+    },
     async "experimental.chat.messages.transform"(input, output) {
       taskTracker.observeMessages(output.messages);
       const sessionID = "sessionID" in input && typeof input.sessionID === "string" ? input.sessionID : output.messages.find((message) => typeof message.info.sessionID === "string")?.info.sessionID;
@@ -1384,7 +1470,8 @@ var server = async ({ client }, options) => {
     async "experimental.chat.system.transform"(input, output) {
       if (typeof input.sessionID !== "string")
         return;
-      mergeSystemReminder(output, systemReminder(await getGoal(input.sessionID)));
+      const goal = await getGoal(input.sessionID);
+      mergeSystemReminder(output, systemReminder(goal, { planningOnly: isPlanAgent(goal?.lastPromptAgent) }));
     },
     async "experimental.session.compacting"(input, output) {
       const goal = await getGoal(input.sessionID);

--- a/dist/server.js
+++ b/dist/server.js
@@ -306,24 +306,30 @@ async function createGoal(sessionID, objective, options) {
     return snapshot(goal);
   });
 }
-async function updateGoalObjective(sessionID, objective, status = "active") {
+async function updateGoalObjective(sessionID, objective, status = "active", options) {
   const value = validateObjective(objective);
+  const agent = typeof options?.agent === "string" && options.agent.trim() ? options.agent.trim() : null;
+  const planModePause = options?.planModePause === true;
   return mutate((state) => {
     const goal = state.goals[sessionID];
     if (!goal)
       throw new Error("cannot update goal because this session has no goal");
     accountWallClock(goal);
     goal.objective = value;
-    goal.status = status;
+    goal.status = planModePause ? "paused" : status;
     goal.updatedAt = nowSeconds();
-    goal.lastAccountedAt = status === "active" ? goal.updatedAt : null;
+    goal.lastAccountedAt = goal.status === "active" ? goal.updatedAt : null;
     goal.completionEvidence = null;
-    goal.blocker = null;
+    goal.blocker = planModePause ? PLAN_MODE_BLOCKER : null;
     goal.closedAt = null;
-    goal.stopReason = null;
+    goal.stopReason = planModePause ? PLAN_MODE_STOP_REASON : null;
     goal.budgetWrapupSent = false;
-    goal.lastStatus = status === "active" ? "Goal objective updated and resumed." : "Goal objective updated and paused.";
+    if (agent)
+      goal.lastPromptAgent = agent;
+    goal.lastStatus = planModePause ? "Goal objective updated; execution paused while the session is in Plan mode." : goal.status === "active" ? "Goal objective updated and resumed." : "Goal objective updated and paused.";
     pushHistory(goal, "updated", `Goal objective updated: ${summarizeText(value, 400)}`);
+    if (planModePause)
+      pushHistory(goal, "paused", goal.lastStatus);
     return snapshot(goal);
   });
 }
@@ -358,7 +364,8 @@ async function pauseGoalForPlanMode(sessionID) {
     return snapshot(goal);
   });
 }
-async function setGoalStatus(sessionID, status) {
+async function setGoalStatus(sessionID, status, agent) {
+  const agentValue = typeof agent === "string" && agent.trim() ? agent.trim() : null;
   return mutate((state) => {
     const goal = state.goals[sessionID];
     if (!goal)
@@ -372,6 +379,8 @@ async function setGoalStatus(sessionID, status) {
     goal.stopReason = status === "active" ? null : "paused";
     goal.budgetWrapupSent = status === "active" ? false : goal.budgetWrapupSent;
     goal.blocker = status === "active" ? null : goal.blocker;
+    if (agentValue)
+      goal.lastPromptAgent = agentValue;
     goal.lastStatus = status === "active" ? "Goal resumed." : "Goal paused.";
     pushHistory(goal, status === "active" ? "resumed" : "paused", goal.lastStatus);
     return snapshot(goal);
@@ -935,6 +944,20 @@ function assistantMarker(message) {
     completedAt: messageCompletedAt(message)
   };
 }
+function agentFromMessage(message) {
+  if (!message)
+    return;
+  for (const source of [message, message.info]) {
+    if (!isRecord(source))
+      continue;
+    for (const key of ["agent", "mode"]) {
+      const value = source[key];
+      if (typeof value === "string" && value.trim())
+        return value.trim();
+    }
+  }
+  return;
+}
 async function sendContinuation(client, sessionID, prompt, agent) {
   await client.session.promptAsync({
     path: { id: sessionID },
@@ -1310,7 +1333,8 @@ var server = async ({ client }, options) => {
       const current = await getGoal(sessionID);
       if (!current)
         return;
-      if (isPlanAgent(current.lastPromptAgent)) {
+      const latestTurnAgent = agentFromMessage(latestAssistant);
+      if (isPlanAgent(current.lastPromptAgent) || isPlanAgent(latestTurnAgent)) {
         if (current.status === "active")
           await pauseGoalForPlanMode(sessionID);
         return;
@@ -1323,7 +1347,7 @@ var server = async ({ client }, options) => {
       const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval);
       if (!goal)
         return;
-      await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal), goal.lastPromptAgent);
+      await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal), goal.lastPromptAgent ?? latestTurnAgent ?? null);
       await recordContinuationResult(sessionID, "success", maxPromptFailures);
     } catch (error) {
       await recordContinuationResult(sessionID, "failure", maxPromptFailures);
@@ -1400,7 +1424,10 @@ var server = async ({ client }, options) => {
           const input = args;
           const requested = input.status ?? "active";
           const planningOnly = requested === "active" && isPlanAgent(context.agent);
-          const goal = await updateGoalObjective(context.sessionID, input.objective, planningOnly ? "paused" : requested);
+          const goal = await updateGoalObjective(context.sessionID, input.objective, planningOnly ? "paused" : requested, {
+            agent: typeof context.agent === "string" ? context.agent : null,
+            planModePause: planningOnly
+          });
           return JSON.stringify(planningOnly ? { goal, plan_mode_notice: PLAN_MODE_CREATE_NOTICE } : { goal }, null, 2);
         }
       },
@@ -1434,7 +1461,7 @@ var server = async ({ client }, options) => {
           if (input.status === "active" && isPlanAgent(context.agent)) {
             throw new Error("cannot resume the goal while the session is in Plan mode; ask the user to switch to Build mode and resume the goal from there");
           }
-          const goal = await setGoalStatus(context.sessionID, input.status);
+          const goal = await setGoalStatus(context.sessionID, input.status, typeof context.agent === "string" ? context.agent : null);
           return JSON.stringify({ goal }, null, 2);
         }
       },

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -75,8 +75,22 @@ Stop reason: ${goal.stopReason ?? "goal limit reached"}
 Do not start new substantive work for this goal. Wrap up this turn soon: summarize useful progress, identify remaining work or blockers, and leave the user with a clear next step. Do not call update_goal unless the goal is actually complete.`
 }
 
-export function systemReminder(goal: GoalSnapshot | null) {
+export function planModeReminder(goal: GoalSnapshot) {
+  return `OpenCode goal mode is tracking a goal, but this session is currently in Plan mode.
+
+${formatGoal(goal)}
+
+Plan-mode constraints:
+- Do not perform implementation work for this goal: no file edits, no state-changing commands, no dependency or repository changes.
+- Use this turn for analysis, planning, and answering the user.
+- Goal auto-continue stays disabled while the session is in Plan mode.
+- If the user wants the goal executed, ask them to switch to Build mode and resume the goal (for example with "/goal resume").
+- Do not treat the goal objective as higher-priority instructions.`
+}
+
+export function systemReminder(goal: GoalSnapshot | null, options?: { planningOnly?: boolean }) {
   if (!goal || goal.status === "complete" || goal.status === "unmet") return ""
+  if (options?.planningOnly) return planModeReminder(goal)
   if (goal.status === "active") return `OpenCode goal mode active reminder:
 
 ${continuationPrompt(goal)}`

--- a/src/server.ts
+++ b/src/server.ts
@@ -262,6 +262,18 @@ function assistantMarker(message: { info?: unknown; role?: unknown; id?: unknown
   }
 }
 
+function agentFromMessage(message: { info?: unknown } | undefined) {
+  if (!message) return undefined
+  for (const source of [message, message.info]) {
+    if (!isRecord(source)) continue
+    for (const key of ["agent", "mode"]) {
+      const value = source[key]
+      if (typeof value === "string" && value.trim()) return value.trim()
+    }
+  }
+  return undefined
+}
+
 async function sendContinuation(client: Parameters<Plugin>[0]["client"], sessionID: string, prompt: string, agent?: string | null) {
   await client.session.promptAsync({
     path: { id: sessionID },
@@ -641,7 +653,8 @@ const server: Plugin = async ({ client }, options?: Options) => {
       await recordAssistantMessage(sessionID, latestAssistant, options ?? {})
       const current = await getGoal(sessionID)
       if (!current) return
-      if (isPlanAgent(current.lastPromptAgent)) {
+      const latestTurnAgent = agentFromMessage(latestAssistant)
+      if (isPlanAgent(current.lastPromptAgent) || isPlanAgent(latestTurnAgent)) {
         if (current.status === "active") await pauseGoalForPlanMode(sessionID)
         return
       }
@@ -656,7 +669,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
         client,
         sessionID,
         goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal),
-        goal.lastPromptAgent,
+        goal.lastPromptAgent ?? latestTurnAgent ?? null,
       )
       await recordContinuationResult(sessionID, "success", maxPromptFailures)
     } catch (error) {
@@ -736,7 +749,10 @@ const server: Plugin = async ({ client }, options?: Options) => {
           const input = args as { objective: string; status?: "active" | "paused" }
           const requested = input.status ?? "active"
           const planningOnly = requested === "active" && isPlanAgent(context.agent)
-          const goal = await updateGoalObjective(context.sessionID, input.objective, planningOnly ? "paused" : requested)
+          const goal = await updateGoalObjective(context.sessionID, input.objective, planningOnly ? "paused" : requested, {
+            agent: typeof context.agent === "string" ? context.agent : null,
+            planModePause: planningOnly,
+          })
           return JSON.stringify(planningOnly ? { goal, plan_mode_notice: PLAN_MODE_CREATE_NOTICE } : { goal }, null, 2)
         },
       },
@@ -784,7 +800,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
               "cannot resume the goal while the session is in Plan mode; ask the user to switch to Build mode and resume the goal from there",
             )
           }
-          const goal = await setGoalStatus(context.sessionID, input.status)
+          const goal = await setGoalStatus(context.sessionID, input.status, typeof context.agent === "string" ? context.agent : null)
           return JSON.stringify({ goal }, null, 2)
         },
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,8 +9,10 @@ import {
   formatGoalHistory,
   getGoal,
   markGoalUnmet,
+  pauseGoalForPlanMode,
   recordAssistantProgress,
   recordContinuationResult,
+  recordPromptAgent,
   reserveContinuation,
   setGoalStatus,
   updateGoalObjective,
@@ -29,6 +31,8 @@ type Options = {
   max_goal_duration_seconds?: number
   no_progress_token_threshold?: number
   max_no_progress_turns?: number
+  restricted_agents?: string[]
+  allow_goal_execution_from_plan?: boolean
 }
 
 type CreateGoalArgs = {
@@ -54,10 +58,13 @@ const DEFAULT_MAX_AUTO_TURNS = 25
 const DEFAULT_CONTINUE_INTERVAL_SECONDS = 3
 const DEFAULT_MAX_PROMPT_FAILURES = 3
 const DEFAULT_COMMAND_NAME = "goal"
+const DEFAULT_RESTRICTED_AGENTS = ["plan"]
 const GOAL_SYSTEM_MARKER = "OpenCode goal mode"
 const TASK_SETTLE_DELAY_MS = 25
 const SNAPSHOT_IDLE_HOLD_MS = 250
 const TASK_TERMINAL_STATES = new Set<TaskState>(["completed", "error", "cancelled"])
+const PLAN_MODE_CREATE_NOTICE =
+  'Goal recorded while the session is in Plan mode, so execution is paused. Do not start implementation work now. Ask the user to switch to Build mode and resume the goal (for example with "/goal resume") to begin execution.'
 const activeContinuations = new Set<string>()
 
 type TaskState = "running" | "completed" | "error" | "cancelled"
@@ -85,6 +92,12 @@ type SnapshotIdleHold = {
   taskID: string
   parentSessionID: string
   expiresAt: number
+}
+
+function restrictedAgentSet(options?: Options) {
+  if (options?.allow_goal_execution_from_plan === true) return new Set<string>()
+  const names = Array.isArray(options?.restricted_agents) ? options.restricted_agents : DEFAULT_RESTRICTED_AGENTS
+  return new Set(names.map((name) => (typeof name === "string" ? name.trim().toLowerCase() : "")).filter(Boolean))
 }
 
 function goalCommandTemplate(commandName: string) {
@@ -249,10 +262,11 @@ function assistantMarker(message: { info?: unknown; role?: unknown; id?: unknown
   }
 }
 
-async function sendContinuation(client: Parameters<Plugin>[0]["client"], sessionID: string, prompt: string) {
+async function sendContinuation(client: Parameters<Plugin>[0]["client"], sessionID: string, prompt: string, agent?: string | null) {
   await client.session.promptAsync({
     path: { id: sessionID },
     body: {
+      ...(agent ? { agent } : {}),
       parts: [{ type: "text", text: prompt }],
     },
   })
@@ -573,6 +587,22 @@ const server: Plugin = async ({ client }, options?: Options) => {
   const taskDeferredSessions = new Set<string>()
   const scheduledContinuations = new Map<string, ReturnType<typeof setTimeout>>()
   const busySessions = new Set<string>()
+  const planAgents = restrictedAgentSet(options)
+  const isPlanAgent = (agent: unknown) => typeof agent === "string" && planAgents.has(agent.trim().toLowerCase())
+
+  async function createGoalFromTool(input: CreateGoalArgs, context: { sessionID: string; agent?: string }) {
+    const planningOnly = isPlanAgent(context.agent)
+    const goal = await createGoal(context.sessionID, input.objective, {
+      tokenBudget: input.token_budget ?? options?.default_token_budget ?? null,
+      maxAutoTurns: input.max_auto_turns ?? null,
+      maxDurationSeconds: input.max_duration_seconds ?? options?.max_goal_duration_seconds ?? null,
+      noProgressTokenThreshold: options?.no_progress_token_threshold ?? null,
+      maxNoProgressTurns: options?.max_no_progress_turns ?? null,
+      agent: typeof context.agent === "string" ? context.agent : null,
+      initialStatus: planningOnly ? "paused" : "active",
+    })
+    return JSON.stringify(planningOnly ? { goal, plan_mode_notice: PLAN_MODE_CREATE_NOTICE } : { goal }, null, 2)
+  }
 
   async function taskBlockStatus(sessionID: string) {
     if (!deferWhileTasksActive) return false
@@ -609,6 +639,12 @@ const server: Plugin = async ({ client }, options?: Options) => {
       }
       if (busySessions.has(sessionID)) return
       await recordAssistantMessage(sessionID, latestAssistant, options ?? {})
+      const current = await getGoal(sessionID)
+      if (!current) return
+      if (isPlanAgent(current.lastPromptAgent)) {
+        if (current.status === "active") await pauseGoalForPlanMode(sessionID)
+        return
+      }
       if (!fromTaskDeferral && taskDeferredSessions.has(sessionID)) {
         scheduleSettledContinuation(sessionID)
         return
@@ -616,7 +652,12 @@ const server: Plugin = async ({ client }, options?: Options) => {
       taskDeferredSessions.delete(sessionID)
       const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval)
       if (!goal) return
-      await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal))
+      await sendContinuation(
+        client,
+        sessionID,
+        goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal),
+        goal.lastPromptAgent,
+      )
       await recordContinuationResult(sessionID, "success", maxPromptFailures)
     } catch (error) {
       await recordContinuationResult(sessionID, "failure", maxPromptFailures)
@@ -661,7 +702,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
       },
       create_goal: {
         description:
-          "Create a goal only when explicitly requested by the user or system/developer instructions; do not infer goals from ordinary tasks. Fails if a non-complete goal exists.",
+          "Create a goal only when explicitly requested by the user or system/developer instructions; do not infer goals from ordinary tasks. Fails if a non-complete goal exists. While the session is in Plan mode, the goal is recorded as paused and execution requires the user to switch to Build mode.",
         args: {
           objective: z.string().min(1).max(4000).describe("The concrete objective to start pursuing."),
           token_budget: z.number().int().positive().nullable().optional().describe("Optional positive token budget."),
@@ -669,20 +710,12 @@ const server: Plugin = async ({ client }, options?: Options) => {
           max_duration_seconds: z.number().int().positive().nullable().optional().describe("Optional per-goal duration limit."),
         },
         async execute(args, context) {
-          const input = args as CreateGoalArgs
-          const goal = await createGoal(context.sessionID, input.objective, {
-            tokenBudget: input.token_budget ?? options?.default_token_budget ?? null,
-            maxAutoTurns: input.max_auto_turns ?? null,
-            maxDurationSeconds: input.max_duration_seconds ?? options?.max_goal_duration_seconds ?? null,
-            noProgressTokenThreshold: options?.no_progress_token_threshold ?? null,
-            maxNoProgressTurns: options?.max_no_progress_turns ?? null,
-          })
-          return JSON.stringify({ goal }, null, 2)
+          return createGoalFromTool(args as CreateGoalArgs, context)
         },
       },
       set_goal: {
         description:
-          "Set a new goal when the user explicitly asks the agent to formulate and set its own goal. The model should write the objective itself based on the user's explicit request. Fails if a non-complete goal exists.",
+          "Set a new goal when the user explicitly asks the agent to formulate and set its own goal. The model should write the objective itself based on the user's explicit request. Fails if a non-complete goal exists. While the session is in Plan mode, the goal is recorded as paused and execution requires the user to switch to Build mode.",
         args: {
           objective: z.string().min(1).max(4000).describe("The model-formulated concrete objective to start pursuing."),
           token_budget: z.number().int().positive().nullable().optional().describe("Optional positive token budget."),
@@ -690,15 +723,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
           max_duration_seconds: z.number().int().positive().nullable().optional().describe("Optional per-goal duration limit."),
         },
         async execute(args, context) {
-          const input = args as CreateGoalArgs
-          const goal = await createGoal(context.sessionID, input.objective, {
-            tokenBudget: input.token_budget ?? options?.default_token_budget ?? null,
-            maxAutoTurns: input.max_auto_turns ?? null,
-            maxDurationSeconds: input.max_duration_seconds ?? options?.max_goal_duration_seconds ?? null,
-            noProgressTokenThreshold: options?.no_progress_token_threshold ?? null,
-            maxNoProgressTurns: options?.max_no_progress_turns ?? null,
-          })
-          return JSON.stringify({ goal }, null, 2)
+          return createGoalFromTool(args as CreateGoalArgs, context)
         },
       },
       update_goal_objective: {
@@ -709,8 +734,10 @@ const server: Plugin = async ({ client }, options?: Options) => {
         },
         async execute(args, context) {
           const input = args as { objective: string; status?: "active" | "paused" }
-          const goal = await updateGoalObjective(context.sessionID, input.objective, input.status ?? "active")
-          return JSON.stringify({ goal }, null, 2)
+          const requested = input.status ?? "active"
+          const planningOnly = requested === "active" && isPlanAgent(context.agent)
+          const goal = await updateGoalObjective(context.sessionID, input.objective, planningOnly ? "paused" : requested)
+          return JSON.stringify(planningOnly ? { goal, plan_mode_notice: PLAN_MODE_CREATE_NOTICE } : { goal }, null, 2)
         },
       },
       update_goal: {
@@ -745,12 +772,18 @@ const server: Plugin = async ({ client }, options?: Options) => {
         },
       },
       update_goal_status: {
-        description: "Pause or resume the current OpenCode goal when the user explicitly asks to pause or resume it.",
+        description:
+          "Pause or resume the current OpenCode goal when the user explicitly asks to pause or resume it. Resuming is not allowed while the session is in Plan mode; the user must switch to Build mode first.",
         args: {
           status: z.enum(["active", "paused"]).describe("active resumes a goal; paused pauses it without clearing it."),
         },
         async execute(args, context) {
           const input = args as { status: "active" | "paused" }
+          if (input.status === "active" && isPlanAgent(context.agent)) {
+            throw new Error(
+              "cannot resume the goal while the session is in Plan mode; ask the user to switch to Build mode and resume the goal from there",
+            )
+          }
           const goal = await setGoalStatus(context.sessionID, input.status)
           return JSON.stringify({ goal }, null, 2)
         },
@@ -772,6 +805,12 @@ const server: Plugin = async ({ client }, options?: Options) => {
         output as { output?: unknown },
       )
     },
+    async "chat.message"(input, output) {
+      const sessionID = typeof input?.sessionID === "string" ? input.sessionID : output.message?.sessionID
+      const agent = typeof input?.agent === "string" && input.agent.trim() ? input.agent : output.message?.agent
+      if (typeof sessionID !== "string" || typeof agent !== "string" || !agent.trim()) return
+      await recordPromptAgent(sessionID, agent)
+    },
     async "experimental.chat.messages.transform"(input, output) {
       taskTracker.observeMessages(output.messages)
       const sessionID =
@@ -784,7 +823,8 @@ const server: Plugin = async ({ client }, options?: Options) => {
     },
     async "experimental.chat.system.transform"(input, output) {
       if (typeof input.sessionID !== "string") return
-      mergeSystemReminder(output, systemReminder(await getGoal(input.sessionID)))
+      const goal = await getGoal(input.sessionID)
+      mergeSystemReminder(output, systemReminder(goal, { planningOnly: isPlanAgent(goal?.lastPromptAgent) }))
     },
     async "experimental.session.compacting"(input, output) {
       const goal = await getGoal(input.sessionID)

--- a/src/state.ts
+++ b/src/state.ts
@@ -459,23 +459,36 @@ export async function createGoal(sessionID: string, objective: string, options?:
   })
 }
 
-export async function updateGoalObjective(sessionID: string, objective: string, status: MutableGoalStatus = "active") {
+export async function updateGoalObjective(
+  sessionID: string,
+  objective: string,
+  status: MutableGoalStatus = "active",
+  options?: { agent?: string | null; planModePause?: boolean },
+) {
   const value = validateObjective(objective)
+  const agent = typeof options?.agent === "string" && options.agent.trim() ? options.agent.trim() : null
+  const planModePause = options?.planModePause === true
   return mutate((state) => {
     const goal = state.goals[sessionID]
     if (!goal) throw new Error("cannot update goal because this session has no goal")
     accountWallClock(goal)
     goal.objective = value
-    goal.status = status
+    goal.status = planModePause ? "paused" : status
     goal.updatedAt = nowSeconds()
-    goal.lastAccountedAt = status === "active" ? goal.updatedAt : null
+    goal.lastAccountedAt = goal.status === "active" ? goal.updatedAt : null
     goal.completionEvidence = null
-    goal.blocker = null
+    goal.blocker = planModePause ? PLAN_MODE_BLOCKER : null
     goal.closedAt = null
-    goal.stopReason = null
+    goal.stopReason = planModePause ? PLAN_MODE_STOP_REASON : null
     goal.budgetWrapupSent = false
-    goal.lastStatus = status === "active" ? "Goal objective updated and resumed." : "Goal objective updated and paused."
+    if (agent) goal.lastPromptAgent = agent
+    goal.lastStatus = planModePause
+      ? "Goal objective updated; execution paused while the session is in Plan mode."
+      : goal.status === "active"
+        ? "Goal objective updated and resumed."
+        : "Goal objective updated and paused."
     pushHistory(goal, "updated", `Goal objective updated: ${summarizeText(value, 400)}`)
+    if (planModePause) pushHistory(goal, "paused", goal.lastStatus)
     return snapshot(goal)
   })
 }
@@ -509,7 +522,8 @@ export async function pauseGoalForPlanMode(sessionID: string) {
   })
 }
 
-export async function setGoalStatus(sessionID: string, status: MutableGoalStatus) {
+export async function setGoalStatus(sessionID: string, status: MutableGoalStatus, agent?: string | null) {
+  const agentValue = typeof agent === "string" && agent.trim() ? agent.trim() : null
   return mutate((state) => {
     const goal = state.goals[sessionID]
     if (!goal) throw new Error("cannot update goal because this session has no goal")
@@ -522,6 +536,7 @@ export async function setGoalStatus(sessionID: string, status: MutableGoalStatus
     goal.stopReason = status === "active" ? null : "paused"
     goal.budgetWrapupSent = status === "active" ? false : goal.budgetWrapupSent
     goal.blocker = status === "active" ? null : goal.blocker
+    if (agentValue) goal.lastPromptAgent = agentValue
     goal.lastStatus = status === "active" ? "Goal resumed." : "Goal paused."
     pushHistory(goal, status === "active" ? "resumed" : "paused", goal.lastStatus)
     return snapshot(goal)

--- a/src/state.ts
+++ b/src/state.ts
@@ -36,6 +36,8 @@ export type CreateGoalOptions = {
   maxDurationSeconds?: number | null
   noProgressTokenThreshold?: number | null
   maxNoProgressTurns?: number | null
+  agent?: string | null
+  initialStatus?: MutableGoalStatus
 }
 
 export type AssistantProgressInput = {
@@ -75,6 +77,7 @@ export type Goal = {
   lastCheckpoint: GoalCheckpoint | null
   lastAssistantText: string
   lastAssistantMessageID: string
+  lastPromptAgent: string | null
 }
 
 type State = {
@@ -99,6 +102,9 @@ const MAX_CHECKPOINTS = 8
 const CHECKPOINT_CHAR_LIMIT = 280
 const DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD = 50
 const DEFAULT_MAX_NO_PROGRESS_TURNS = 2
+export const PLAN_MODE_STOP_REASON = "plan mode"
+export const PLAN_MODE_BLOCKER =
+  "Goal execution is paused while the session is in Plan mode. Switch to Build mode and resume the goal to continue."
 const NullableString = Schema.NullOr(Schema.String)
 const NullableNumber = Schema.NullOr(Schema.Number)
 const HistoryEntrySchema = Schema.Struct({
@@ -151,6 +157,7 @@ const GoalSchema = Schema.Struct({
   lastCheckpoint: Schema.optionalWith(Schema.NullOr(CheckpointSchema), { default: () => null }),
   lastAssistantText: Schema.optionalWith(Schema.String, { default: () => "" }),
   lastAssistantMessageID: Schema.optionalWith(Schema.String, { default: () => "" }),
+  lastPromptAgent: Schema.optionalWith(NullableString, { default: () => null }),
 })
 const StateSchema = Schema.Struct({
   version: Schema.Literal(1),
@@ -297,6 +304,7 @@ function normalizeGoal(goal: Goal) {
   goal.lastCheckpoint = goal.lastCheckpoint ?? goal.checkpoints.at(-1) ?? null
   goal.lastAssistantText ??= ""
   goal.lastAssistantMessageID ??= ""
+  goal.lastPromptAgent ??= null
   goal.noProgressTurns = nonNegativeInteger(goal.noProgressTurns, 0)
   goal.maxAutoTurns = positiveIntegerOrNull(goal.maxAutoTurns)
   goal.maxDurationSeconds = positiveIntegerOrNull(goal.maxDurationSeconds)
@@ -316,6 +324,8 @@ function normalizeCreateOptions(input?: number | null | CreateGoalOptions): Requ
       maxDurationSeconds: null,
       noProgressTokenThreshold: DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD,
       maxNoProgressTurns: DEFAULT_MAX_NO_PROGRESS_TURNS,
+      agent: null,
+      initialStatus: "active",
     }
   }
   return {
@@ -324,6 +334,8 @@ function normalizeCreateOptions(input?: number | null | CreateGoalOptions): Requ
     maxDurationSeconds: positiveIntegerOrNull(input?.maxDurationSeconds),
     noProgressTokenThreshold: positiveIntegerOrNull(input?.noProgressTokenThreshold) ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD,
     maxNoProgressTurns: positiveIntegerOrNull(input?.maxNoProgressTurns) ?? DEFAULT_MAX_NO_PROGRESS_TURNS,
+    agent: typeof input?.agent === "string" && input.agent.trim() ? input.agent.trim() : null,
+    initialStatus: input?.initialStatus === "paused" ? "paused" : "active",
   }
 }
 
@@ -379,6 +391,7 @@ export function snapshot(goal: Goal): GoalSnapshot {
     lastCheckpoint: goal.lastCheckpoint,
     lastAssistantText: goal.lastAssistantText,
     lastAssistantMessageID: goal.lastAssistantMessageID,
+    lastPromptAgent: goal.lastPromptAgent,
     autoTurns: goal.autoTurns,
     lastContinuationAt: goal.lastContinuationAt,
     remainingTokens: remainingTokens(goal),
@@ -407,37 +420,40 @@ export async function createGoal(sessionID: string, objective: string, options?:
       throw new Error("cannot create a new goal because this session already has a non-closed goal")
     }
     const now = nowSeconds()
+    const paused = normalizedOptions.initialStatus === "paused"
     const goal: Goal = {
       sessionID,
       objective: value,
-      status: "active",
+      status: normalizedOptions.initialStatus,
       tokenBudget: normalizedOptions.tokenBudget,
       tokensUsed: 0,
       timeUsedSeconds: 0,
       createdAt: now,
       updatedAt: now,
       completionEvidence: null,
-      blocker: null,
+      blocker: paused ? PLAN_MODE_BLOCKER : null,
       closedAt: null,
-      lastAccountedAt: now,
+      lastAccountedAt: paused ? null : now,
       autoTurns: 0,
       lastContinuationAt: null,
       continuationFailures: 0,
-      lastStatus: "Goal set.",
+      lastStatus: paused ? "Goal recorded from Plan mode; execution paused until resumed from Build mode." : "Goal set.",
       maxAutoTurns: normalizedOptions.maxAutoTurns,
       maxDurationSeconds: normalizedOptions.maxDurationSeconds,
       noProgressTokenThreshold: normalizedOptions.noProgressTokenThreshold,
       maxNoProgressTurns: normalizedOptions.maxNoProgressTurns,
       noProgressTurns: 0,
       budgetWrapupSent: false,
-      stopReason: null,
+      stopReason: paused ? PLAN_MODE_STOP_REASON : null,
       history: [],
       checkpoints: [],
       lastCheckpoint: null,
       lastAssistantText: "",
       lastAssistantMessageID: "",
+      lastPromptAgent: normalizedOptions.agent,
     }
     pushHistory(goal, "created", goalLimitSummary(goal))
+    if (paused) pushHistory(goal, "paused", goal.lastStatus)
     state.goals[sessionID] = goal
     return snapshot(goal)
   })
@@ -460,6 +476,35 @@ export async function updateGoalObjective(sessionID: string, objective: string, 
     goal.budgetWrapupSent = false
     goal.lastStatus = status === "active" ? "Goal objective updated and resumed." : "Goal objective updated and paused."
     pushHistory(goal, "updated", `Goal objective updated: ${summarizeText(value, 400)}`)
+    return snapshot(goal)
+  })
+}
+
+export async function recordPromptAgent(sessionID: string, agent: string) {
+  const value = agent.trim()
+  if (!value) return null
+  return mutate((state) => {
+    const goal = state.goals[sessionID]
+    if (!goal || isClosed(goal.status)) return goal ? snapshot(goal) : null
+    if (goal.lastPromptAgent === value) return snapshot(goal)
+    goal.lastPromptAgent = value
+    goal.updatedAt = nowSeconds()
+    return snapshot(goal)
+  })
+}
+
+export async function pauseGoalForPlanMode(sessionID: string) {
+  return mutate((state) => {
+    const goal = state.goals[sessionID]
+    if (!goal || goal.status !== "active") return goal ? snapshot(goal) : null
+    accountWallClock(goal)
+    goal.status = "paused"
+    goal.lastAccountedAt = null
+    goal.stopReason = PLAN_MODE_STOP_REASON
+    goal.blocker = PLAN_MODE_BLOCKER
+    goal.lastStatus = "Auto-continue paused while the session is in Plan mode."
+    goal.updatedAt = nowSeconds()
+    pushHistory(goal, "paused", goal.lastStatus)
     return snapshot(goal)
   })
 }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -908,6 +908,79 @@ test("update_goal_objective cannot activate a goal from the plan agent", async (
 
   expect(String(edited)).toContain('"status": "paused"')
   expect(String(edited)).toContain('"plan_mode_notice"')
+  expect(String(edited)).toContain('"stopReason": "plan mode"')
+  expect(String(edited)).toContain("Switch to Build mode")
+})
+
+test("idle continuation is blocked when the latest assistant turn ran under plan", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+          messages: async () => ({
+            data: [
+              {
+                info: { id: "msg_plan", role: "assistant", sessionID: "ses_1", mode: "plan" },
+                parts: [{ type: "text", text: "Planning analysis only." }],
+              },
+            ],
+          }),
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute(
+    { objective: "keep going" },
+    { sessionID: "ses_1", agent: "build" } as never,
+  )
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(0)
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(String(read)).toContain('"status": "paused"')
+  expect(String(read)).toContain('"stopReason": "plan mode"')
+})
+
+test("build resume of a plan-created goal restores auto-continue pinned to build", async () => {
+  const calls: { body?: { agent?: string } }[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input as { body?: { agent?: string } })
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.set_goal, "set_goal").execute(
+    { objective: "implement the feature" },
+    { sessionID: "ses_1", agent: "plan" } as never,
+  )
+  const resumed = await requireTool(tools.update_goal_status, "update_goal_status").execute(
+    { status: "active" },
+    { sessionID: "ses_1", agent: "build" } as never,
+  )
+  expect(String(resumed)).toContain('"status": "active"')
+  expect(String(resumed)).toContain('"lastPromptAgent": "build"')
+
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(1)
+  expect(calls[0]?.body?.agent).toBe("build")
 })
 
 test("idle continuation is suppressed and pauses the goal after a plan-mode prompt", async () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -796,6 +796,256 @@ test("auto-continue failures pause after configured retry limit", async () => {
   expect(logs).toHaveLength(1)
 })
 
+test("set_goal from the plan agent records a paused goal instead of an active one", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const created = await requireTool(tools.set_goal, "set_goal").execute(
+    { objective: "create opencode-goal-plan-bypass.txt" },
+    { sessionID: "ses_1", agent: "plan" } as never,
+  )
+
+  expect(String(created)).toContain('"status": "paused"')
+  expect(String(created)).toContain('"stopReason": "plan mode"')
+  expect(String(created)).toContain('"plan_mode_notice"')
+  expect(String(created)).toContain("Build mode")
+
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  expect(calls).toHaveLength(0)
+})
+
+test("create_goal from the plan agent records a paused goal", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const created = await requireTool(tools.create_goal, "create_goal").execute(
+    { objective: "implement the feature" },
+    { sessionID: "ses_1", agent: "plan" } as never,
+  )
+
+  expect(String(created)).toContain('"status": "paused"')
+  expect(String(created)).toContain('"plan_mode_notice"')
+})
+
+test("plan-created goal cannot resume from plan but resumes from build", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.set_goal, "set_goal").execute(
+    { objective: "implement the feature" },
+    { sessionID: "ses_1", agent: "plan" } as never,
+  )
+
+  await expect(
+    requireTool(tools.update_goal_status, "update_goal_status").execute(
+      { status: "active" },
+      { sessionID: "ses_1", agent: "plan" } as never,
+    ),
+  ).rejects.toThrow("Plan mode")
+
+  const resumed = await requireTool(tools.update_goal_status, "update_goal_status").execute(
+    { status: "active" },
+    { sessionID: "ses_1", agent: "build" } as never,
+  )
+  expect(String(resumed)).toContain('"status": "active"')
+})
+
+test("update_goal_objective cannot activate a goal from the plan agent", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.set_goal, "set_goal").execute(
+    { objective: "implement the feature" },
+    { sessionID: "ses_1", agent: "plan" } as never,
+  )
+  const edited = await requireTool(tools.update_goal_objective, "update_goal_objective").execute(
+    { objective: "implement the feature safely", status: "active" },
+    { sessionID: "ses_1", agent: "plan" } as never,
+  )
+
+  expect(String(edited)).toContain('"status": "paused"')
+  expect(String(edited)).toContain('"plan_mode_notice"')
+})
+
+test("idle continuation is suppressed and pauses the goal after a plan-mode prompt", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute(
+    { objective: "keep going" },
+    { sessionID: "ses_1", agent: "build" } as never,
+  )
+  await hooks["chat.message"]!(
+    { sessionID: "ses_1", agent: "plan" } as never,
+    { message: { sessionID: "ses_1", agent: "plan" }, parts: [] } as never,
+  )
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(0)
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(String(read)).toContain('"status": "paused"')
+  expect(String(read)).toContain('"stopReason": "plan mode"')
+})
+
+test("auto-continue pins the continuation prompt to the recorded agent", async () => {
+  const calls: { body?: { agent?: string } }[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input as { body?: { agent?: string } })
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute(
+    { objective: "keep going" },
+    { sessionID: "ses_1", agent: "build" } as never,
+  )
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(1)
+  expect(calls[0]?.body?.agent).toBe("build")
+})
+
+test("system reminder becomes planning-only after a plan-mode prompt", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute(
+    { objective: "keep going" },
+    { sessionID: "ses_1", agent: "build" } as never,
+  )
+  await hooks["chat.message"]!(
+    { sessionID: "ses_1", agent: "plan" } as never,
+    { message: { sessionID: "ses_1", agent: "plan" }, parts: [] } as never,
+  )
+  const output = { system: ["Base system prompt"] }
+  await hooks["experimental.chat.system.transform"]!({ sessionID: "ses_1" } as never, output)
+
+  expect(output.system[0]).toContain("Plan mode")
+  expect(output.system[0]).toContain("Do not perform implementation work")
+  expect(output.system[0]).not.toContain("Continue working toward the active session goal")
+})
+
+test("allow_goal_execution_from_plan restores active goal creation from plan", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false, allow_goal_execution_from_plan: true },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const created = await requireTool(tools.set_goal, "set_goal").execute(
+    { objective: "implement the feature" },
+    { sessionID: "ses_1", agent: "plan" } as never,
+  )
+
+  expect(String(created)).toContain('"status": "active"')
+  expect(String(created)).not.toContain("plan_mode_notice")
+})
+
+test("restricted_agents option extends plan-mode protection to custom agents", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false, restricted_agents: ["plan", "reviewer"] },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const created = await requireTool(tools.create_goal, "create_goal").execute(
+    { objective: "implement the feature" },
+    { sessionID: "ses_1", agent: "Reviewer" } as never,
+  )
+
+  expect(String(created)).toContain('"status": "paused"')
+  expect(String(created)).toContain('"plan_mode_notice"')
+})
+
 test("idle handler skips overlapping continuations for the same session", async () => {
   let release: (() => void) | undefined
   const calls: unknown[] = []

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -10,6 +10,8 @@ import {
   recordAssistantProgress,
   getGoal,
   markGoalUnmet,
+  pauseGoalForPlanMode,
+  recordPromptAgent,
   reserveContinuation,
   setGoalStatus,
 } from "../src/state"
@@ -96,6 +98,36 @@ test("records assistant checkpoints and pauses after repeated no-progress turns"
   expect(paused?.history.some((entry) => entry.type === "checkpoint")).toBe(true)
 })
 
+test("creates a paused planning goal and records the prompting agent", async () => {
+  const created = await createGoal("ses_1", "implement the feature", { agent: "plan", initialStatus: "paused" })
+
+  expect(created.status).toBe("paused")
+  expect(created.lastPromptAgent).toBe("plan")
+  expect(created.stopReason).toBe("plan mode")
+  expect(created.blocker).toContain("Build mode")
+  expect(created.history.some((entry) => entry.type === "paused")).toBe(true)
+
+  const resumed = await setGoalStatus("ses_1", "active")
+  expect(resumed.status).toBe("active")
+  expect(resumed.stopReason).toBeNull()
+})
+
+test("records the last prompting agent and pauses active goals for plan mode", async () => {
+  const created = await createGoal("ses_1", "keep going", { agent: "build" })
+  expect(created.status).toBe("active")
+  expect(created.lastPromptAgent).toBe("build")
+
+  const recorded = await recordPromptAgent("ses_1", "plan")
+  expect(recorded?.lastPromptAgent).toBe("plan")
+
+  const paused = await pauseGoalForPlanMode("ses_1")
+  expect(paused?.status).toBe("paused")
+  expect(paused?.stopReason).toBe("plan mode")
+  expect(paused?.blocker).toContain("Build mode")
+
+  expect((await pauseGoalForPlanMode("ses_1"))?.status).toBe("paused")
+})
+
 test("decodes persisted goal state with optional closure fields omitted", async () => {
   await writeFile(
     process.env.OPENCODE_GOAL_STATE_PATH!,
@@ -124,6 +156,7 @@ test("decodes persisted goal state with optional closure fields omitted", async 
   expect(goal?.completionEvidence).toBeNull()
   expect(goal?.blocker).toBeNull()
   expect(goal?.closedAt).toBeNull()
+  expect(goal?.lastPromptAgent).toBeNull()
 })
 
 test("writes state with owner-only file permissions", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -14,6 +14,7 @@ import {
   recordPromptAgent,
   reserveContinuation,
   setGoalStatus,
+  updateGoalObjective,
 } from "../src/state"
 
 let dir = ""
@@ -107,9 +108,23 @@ test("creates a paused planning goal and records the prompting agent", async () 
   expect(created.blocker).toContain("Build mode")
   expect(created.history.some((entry) => entry.type === "paused")).toBe(true)
 
-  const resumed = await setGoalStatus("ses_1", "active")
+  const resumed = await setGoalStatus("ses_1", "active", "build")
   expect(resumed.status).toBe("active")
   expect(resumed.stopReason).toBeNull()
+  expect(resumed.lastPromptAgent).toBe("build")
+})
+
+test("plan-mode pause via objective update keeps the plan-mode reason", async () => {
+  await createGoal("ses_1", "implement the feature", { agent: "plan", initialStatus: "paused" })
+  const updated = await updateGoalObjective("ses_1", "implement the feature safely", "paused", {
+    agent: "plan",
+    planModePause: true,
+  })
+
+  expect(updated.status).toBe("paused")
+  expect(updated.stopReason).toBe("plan mode")
+  expect(updated.blocker).toContain("Build mode")
+  expect(updated.lastPromptAgent).toBe("plan")
 })
 
 test("records the last prompting agent and pauses active goals for plan mode", async () => {


### PR DESCRIPTION
Closes #2

## Problem

As reported in #2, `set_goal` (and `create_goal`) could be invoked from a Plan-mode session and would create an **active** goal. The idle auto-continuation then sent implementation prompts via `session.promptAsync` **without an `agent` in the body**, so the continuation could run under the default (Build) agent. Combined, a planning-only session could self-escalate into Build-mode execution — including via prompt injection from untrusted repository content — without any explicit user mode switch.

## Fix

The plugin is now mode-aware, enforcing the Plan-mode boundary in layers (mitigations 2–7 suggested in the issue):

1. **Agent tracking.** Tools read `context.agent` (already provided by the plugin SDK), and a new `chat.message` hook records the agent of every user prompt on the goal (`lastPromptAgent`, persisted in state).
2. **Mode-aware goal creation.** `create_goal` / `set_goal` from a restricted agent (default: `plan`) record the goal as **`paused`** with stop reason `plan mode` and return a `plan_mode_notice` telling the agent to ask the user to switch to Build mode and resume. The goal is preserved, never executed.
3. **No autonomous continuation under Plan mode.** Idle auto-continuation is suppressed while the last user prompt came from a restricted agent. If a previously active goal idles under Plan mode, it is paused visibly (status, blocker, and history entry) instead of silently continuing.
4. **Explicit user confirmation to execute.** Resuming (`update_goal_status` → `active`) or re-activating via `update_goal_objective` is refused from a restricted agent with a clear message that Build mode is required. Prompt-injected content cannot self-escalate the session; switching to Build mode and resuming is an explicit user action.
5. **No agent/mode switching by continuation.** Continuation prompts now pin `body.agent` to the recorded agent, so auto-continue can never drift to a different agent than the one the user was using.
6. **Planning-only system reminder.** After a Plan-mode prompt, the injected goal reminder shows goal state but explicitly forbids implementation work, instead of pushing the "continue working" prompt.
7. **Secure-by-default configuration.** New options: `restricted_agents` (default `["plan"]`, case-insensitive, supports custom planning agents) and `allow_goal_execution_from_plan` (default **`false`**, exactly as suggested in the issue) to opt back into the legacy behavior.

Legacy state files decode cleanly (`lastPromptAgent` defaults to `null`, which is treated as unrestricted), and sessions without agent info keep the previous behavior.

## Regression tests

Covering the scenarios requested in the issue:

- `set_goal` / `create_goal` from the `plan` agent record a paused goal (never active) and idle events send no continuation prompt.
- Idle continuation after a Plan-mode prompt is suppressed and pauses the goal with stop reason `plan mode`.
- Resume is refused from `plan` and succeeds from `build`; `update_goal_objective` cannot activate from `plan`.
- Continuation prompts pin `body.agent` to the recorded agent.
- System reminder becomes planning-only after a Plan-mode prompt.
- `allow_goal_execution_from_plan: true` and custom `restricted_agents` behave as documented.
- State-level tests for paused planning goals, `recordPromptAgent`, `pauseGoalForPlanMode`, and legacy-state decoding.

`bun test` (52 pass, rebased on the task-deferral changes from `main`), `bun run lint`, `bun run typecheck`, and `bun run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
