### PR TITLE
Scope no-progress accounting to goal continuation turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Defaults:
 - `max_prompt_failures`: `3`
 - `default_token_budget`: unset by default; when set, new goals inherit this token budget.
 - `max_goal_duration_seconds`: unset by default; when set, new goals inherit this elapsed-time safety limit.
-- `no_progress_token_threshold`: `50`
-- `max_no_progress_turns`: `2`
+- `no_progress_token_threshold`: `50`; output-token floor used to judge whether a goal continuation turn made progress.
+- `max_no_progress_turns`: `2`; consecutive low-progress goal continuation turns before pausing. Only turns produced by a reserved goal continuation count — ordinary low-output assistant messages (for example short tool-call-only turns from PTY or status checks) never increment this counter.
 - `register_command`: `true`
 - `command_name`: `"goal"`
 - `restricted_agents`: `["plan"]`; agents (matched case-insensitively) treated as planning-only for goal execution.
@@ -138,7 +138,7 @@ The plugin also uses safety states while keeping the goal available for review o
 
 - `budgetLimited` when a token budget is exhausted.
 - `usageLimited` when an auto-turn or elapsed-time budget is exhausted.
-- `paused` when the user pauses, auto-continue repeatedly fails, or repeated low-output/no-progress turns are detected.
+- `paused` when the user pauses, auto-continue repeatedly fails, or repeated low-progress goal continuation turns are detected. No-progress accounting is scoped to goal continuation turns: each reserved continuation is evaluated once, when its turn completes, and unrelated assistant activity in the session never pauses the goal.
 
 When a safety limit is reached, the plugin sends one wrap-up prompt asking for a concise handoff instead of silently continuing forever.
 

--- a/dist/server.js
+++ b/dist/server.js
@@ -63,7 +63,10 @@ var GoalSchema = Schema.Struct({
   lastCheckpoint: Schema.optionalWith(Schema.NullOr(CheckpointSchema), { default: () => null }),
   lastAssistantText: Schema.optionalWith(Schema.String, { default: () => "" }),
   lastAssistantMessageID: Schema.optionalWith(Schema.String, { default: () => "" }),
-  lastPromptAgent: Schema.optionalWith(NullableString, { default: () => null })
+  lastPromptAgent: Schema.optionalWith(NullableString, { default: () => null }),
+  awaitingContinuationProgress: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  continuationBaselineMessageID: Schema.optionalWith(Schema.String, { default: () => "" }),
+  continuationBaselineSummary: Schema.optionalWith(Schema.String, { default: () => "" })
 });
 var StateSchema = Schema.Struct({
   version: Schema.Literal(1),
@@ -168,6 +171,9 @@ function normalizeGoal(goal) {
   goal.lastAssistantText ??= "";
   goal.lastAssistantMessageID ??= "";
   goal.lastPromptAgent ??= null;
+  goal.awaitingContinuationProgress = goal.awaitingContinuationProgress === true;
+  goal.continuationBaselineMessageID ??= "";
+  goal.continuationBaselineSummary ??= "";
   goal.noProgressTurns = nonNegativeInteger(goal.noProgressTurns, 0);
   goal.maxAutoTurns = positiveIntegerOrNull(goal.maxAutoTurns);
   goal.maxDurationSeconds = positiveIntegerOrNull(goal.maxDurationSeconds);
@@ -247,6 +253,9 @@ function snapshot(goal) {
     lastAssistantText: goal.lastAssistantText,
     lastAssistantMessageID: goal.lastAssistantMessageID,
     lastPromptAgent: goal.lastPromptAgent,
+    awaitingContinuationProgress: goal.awaitingContinuationProgress,
+    continuationBaselineMessageID: goal.continuationBaselineMessageID,
+    continuationBaselineSummary: goal.continuationBaselineSummary,
     autoTurns: goal.autoTurns,
     lastContinuationAt: goal.lastContinuationAt,
     remainingTokens: remainingTokens(goal),
@@ -297,7 +306,10 @@ async function createGoal(sessionID, objective, options) {
       lastCheckpoint: null,
       lastAssistantText: "",
       lastAssistantMessageID: "",
-      lastPromptAgent: normalizedOptions.agent
+      lastPromptAgent: normalizedOptions.agent,
+      awaitingContinuationProgress: false,
+      continuationBaselineMessageID: "",
+      continuationBaselineSummary: ""
     };
     pushHistory(goal, "created", goalLimitSummary(goal));
     if (paused)
@@ -459,24 +471,28 @@ async function recordAssistantProgress(sessionID, input) {
       goal.lastAssistantText = text;
     if (messageID)
       goal.lastAssistantMessageID = messageID;
-    const lowOutput = outputTokens > 0 && outputTokens < (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD);
-    const stalled = lowOutput && (repeatedMessage || !changed);
-    if (stalled) {
-      goal.noProgressTurns += 1;
-      if (maxNoProgressTurns && goal.noProgressTurns >= maxNoProgressTurns) {
-        accountWallClock(goal);
-        goal.status = "paused";
-        goal.lastAccountedAt = null;
-        goal.stopReason = "no progress";
-        goal.blocker = `Auto-continue paused after ${goal.noProgressTurns} low-progress turn(s). Resume the goal to retry.`;
-        goal.lastStatus = goal.blocker;
-        pushHistory(goal, "warning", goal.blocker);
+    const continuationTurnCompleted = input.evaluateContinuation === true && goal.awaitingContinuationProgress && Boolean(messageID) && messageID !== goal.continuationBaselineMessageID;
+    if (continuationTurnCompleted) {
+      goal.awaitingContinuationProgress = false;
+      const lowOutput = outputTokens > 0 && outputTokens < (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD);
+      const changedSinceContinuation = Boolean(summary && summary !== goal.continuationBaselineSummary);
+      if (lowOutput && !changedSinceContinuation) {
+        goal.noProgressTurns += 1;
+        if (maxNoProgressTurns && goal.noProgressTurns >= maxNoProgressTurns) {
+          accountWallClock(goal);
+          goal.status = "paused";
+          goal.lastAccountedAt = null;
+          goal.stopReason = "no progress";
+          goal.blocker = `Auto-continue paused after ${goal.noProgressTurns} low-progress continuation turn(s). Resume the goal to retry.`;
+          goal.lastStatus = goal.blocker;
+          pushHistory(goal, "warning", goal.blocker);
+        } else {
+          goal.lastStatus = `Low-progress continuation turn detected (${goal.noProgressTurns}/${maxNoProgressTurns ?? "unbounded"}).`;
+          pushHistory(goal, "warning", goal.lastStatus);
+        }
       } else {
-        goal.lastStatus = `Low-progress turn detected (${goal.noProgressTurns}/${maxNoProgressTurns ?? "unbounded"}).`;
-        pushHistory(goal, "warning", goal.lastStatus);
+        goal.noProgressTurns = 0;
       }
-    } else if (changed || outputTokens >= (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD)) {
-      goal.noProgressTurns = 0;
     }
     goal.updatedAt = nowSeconds();
     return snapshot(goal);
@@ -499,6 +515,9 @@ async function reserveContinuation(sessionID, maxAutoTurns, minIntervalSeconds) 
       return null;
     goal.autoTurns += 1;
     goal.lastContinuationAt = now;
+    goal.awaitingContinuationProgress = true;
+    goal.continuationBaselineMessageID = goal.lastAssistantMessageID;
+    goal.continuationBaselineSummary = summarizeText(goal.lastAssistantText);
     goal.lastStatus = `Auto-continue ${goal.autoTurns} reserved.`;
     pushHistory(goal, "autoContinue", goal.lastStatus);
     goal.updatedAt = now;
@@ -883,13 +902,16 @@ function exactTokensFromMessage(message) {
   return;
 }
 function outputTokensFromMessage(message) {
+  let total;
   for (const part of message.parts ?? []) {
     if (part && typeof part === "object" && part.type === "step-finish") {
       const output = outputTokensFromRecord(part.tokens);
       if (output != null)
-        return output;
+        total = (total ?? 0) + output;
     }
   }
+  if (total != null)
+    return total;
   if (message.info && typeof message.info === "object")
     return outputTokensFromRecord(message.info.tokens);
   return;
@@ -1239,7 +1261,7 @@ class TaskTracker {
     return false;
   }
 }
-async function recordAssistantMessage(sessionID, message, options) {
+async function recordAssistantMessage(sessionID, message, options, evaluateContinuation = false) {
   if (!message)
     return;
   await recordAssistantProgress(sessionID, {
@@ -1247,7 +1269,8 @@ async function recordAssistantMessage(sessionID, message, options) {
     text: textFromMessage(message),
     outputTokens: outputTokensFromMessage(message) ?? null,
     noProgressTokenThreshold: positiveIntegerOrNull2(options.no_progress_token_threshold),
-    maxNoProgressTurns: positiveIntegerOrNull2(options.max_no_progress_turns)
+    maxNoProgressTurns: positiveIntegerOrNull2(options.max_no_progress_turns),
+    evaluateContinuation
   });
 }
 function mergeSystemReminder(output, reminder) {
@@ -1329,7 +1352,7 @@ var server = async ({ client }, options) => {
       }
       if (busySessions.has(sessionID))
         return;
-      await recordAssistantMessage(sessionID, latestAssistant, options ?? {});
+      await recordAssistantMessage(sessionID, latestAssistant, options ?? {}, true);
       const current = await getGoal(sessionID);
       if (!current)
         return;

--- a/dist/server.js
+++ b/dist/server.js
@@ -515,7 +515,6 @@ async function reserveContinuation(sessionID, maxAutoTurns, minIntervalSeconds) 
       return null;
     goal.autoTurns += 1;
     goal.lastContinuationAt = now;
-    goal.awaitingContinuationProgress = true;
     goal.continuationBaselineMessageID = goal.lastAssistantMessageID;
     goal.continuationBaselineSummary = summarizeText(goal.lastAssistantText);
     goal.lastStatus = `Auto-continue ${goal.autoTurns} reserved.`;
@@ -533,11 +532,14 @@ async function recordContinuationResult(sessionID, result, maxFailures) {
     goal.updatedAt = now;
     if (result === "success") {
       goal.continuationFailures = 0;
-      if (goal.status === "active")
+      if (goal.status === "active") {
         goal.lastStatus = "Auto-continue prompt sent.";
+        goal.awaitingContinuationProgress = true;
+      }
       return snapshot(goal);
     }
     goal.continuationFailures += 1;
+    goal.awaitingContinuationProgress = false;
     goal.lastStatus = `Auto-continue failed ${goal.continuationFailures} time(s).`;
     pushHistory(goal, "error", goal.lastStatus);
     if (goal.continuationFailures >= maxFailures) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -200,12 +200,14 @@ function exactTokensFromMessage(message: { info?: unknown; parts?: unknown[] }) 
 }
 
 function outputTokensFromMessage(message: { info?: unknown; parts?: unknown[] }) {
+  let total: number | undefined
   for (const part of message.parts ?? []) {
     if (part && typeof part === "object" && (part as Record<string, unknown>).type === "step-finish") {
       const output = outputTokensFromRecord((part as Record<string, unknown>).tokens)
-      if (output != null) return output
+      if (output != null) total = (total ?? 0) + output
     }
   }
+  if (total != null) return total
   if (message.info && typeof message.info === "object") return outputTokensFromRecord((message.info as Record<string, unknown>).tokens)
   return undefined
 }
@@ -566,6 +568,7 @@ async function recordAssistantMessage(
   sessionID: string,
   message: { info?: unknown; role?: unknown; id?: unknown; parts?: unknown[] } | undefined,
   options: Options,
+  evaluateContinuation = false,
 ) {
   if (!message) return
   await recordAssistantProgress(sessionID, {
@@ -574,6 +577,7 @@ async function recordAssistantMessage(
     outputTokens: outputTokensFromMessage(message) ?? null,
     noProgressTokenThreshold: positiveIntegerOrNull(options.no_progress_token_threshold),
     maxNoProgressTurns: positiveIntegerOrNull(options.max_no_progress_turns),
+    evaluateContinuation,
   })
 }
 
@@ -650,7 +654,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
         return
       }
       if (busySessions.has(sessionID)) return
-      await recordAssistantMessage(sessionID, latestAssistant, options ?? {})
+      await recordAssistantMessage(sessionID, latestAssistant, options ?? {}, true)
       const current = await getGoal(sessionID)
       if (!current) return
       const latestTurnAgent = agentFromMessage(latestAssistant)

--- a/src/state.ts
+++ b/src/state.ts
@@ -46,6 +46,7 @@ export type AssistantProgressInput = {
   outputTokens?: number | null
   noProgressTokenThreshold?: number | null
   maxNoProgressTurns?: number | null
+  evaluateContinuation?: boolean
 }
 
 export type Goal = {
@@ -78,6 +79,9 @@ export type Goal = {
   lastAssistantText: string
   lastAssistantMessageID: string
   lastPromptAgent: string | null
+  awaitingContinuationProgress: boolean
+  continuationBaselineMessageID: string
+  continuationBaselineSummary: string
 }
 
 type State = {
@@ -158,6 +162,9 @@ const GoalSchema = Schema.Struct({
   lastAssistantText: Schema.optionalWith(Schema.String, { default: () => "" }),
   lastAssistantMessageID: Schema.optionalWith(Schema.String, { default: () => "" }),
   lastPromptAgent: Schema.optionalWith(NullableString, { default: () => null }),
+  awaitingContinuationProgress: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  continuationBaselineMessageID: Schema.optionalWith(Schema.String, { default: () => "" }),
+  continuationBaselineSummary: Schema.optionalWith(Schema.String, { default: () => "" }),
 })
 const StateSchema = Schema.Struct({
   version: Schema.Literal(1),
@@ -305,6 +312,9 @@ function normalizeGoal(goal: Goal) {
   goal.lastAssistantText ??= ""
   goal.lastAssistantMessageID ??= ""
   goal.lastPromptAgent ??= null
+  goal.awaitingContinuationProgress = goal.awaitingContinuationProgress === true
+  goal.continuationBaselineMessageID ??= ""
+  goal.continuationBaselineSummary ??= ""
   goal.noProgressTurns = nonNegativeInteger(goal.noProgressTurns, 0)
   goal.maxAutoTurns = positiveIntegerOrNull(goal.maxAutoTurns)
   goal.maxDurationSeconds = positiveIntegerOrNull(goal.maxDurationSeconds)
@@ -392,6 +402,9 @@ export function snapshot(goal: Goal): GoalSnapshot {
     lastAssistantText: goal.lastAssistantText,
     lastAssistantMessageID: goal.lastAssistantMessageID,
     lastPromptAgent: goal.lastPromptAgent,
+    awaitingContinuationProgress: goal.awaitingContinuationProgress,
+    continuationBaselineMessageID: goal.continuationBaselineMessageID,
+    continuationBaselineSummary: goal.continuationBaselineSummary,
     autoTurns: goal.autoTurns,
     lastContinuationAt: goal.lastContinuationAt,
     remainingTokens: remainingTokens(goal),
@@ -451,6 +464,9 @@ export async function createGoal(sessionID: string, objective: string, options?:
       lastAssistantText: "",
       lastAssistantMessageID: "",
       lastPromptAgent: normalizedOptions.agent,
+      awaitingContinuationProgress: false,
+      continuationBaselineMessageID: "",
+      continuationBaselineSummary: "",
     }
     pushHistory(goal, "created", goalLimitSummary(goal))
     if (paused) pushHistory(goal, "paused", goal.lastStatus)
@@ -629,24 +645,36 @@ export async function recordAssistantProgress(sessionID: string, input: Assistan
     if (text) goal.lastAssistantText = text
     if (messageID) goal.lastAssistantMessageID = messageID
 
-    const lowOutput = outputTokens > 0 && outputTokens < (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD)
-    const stalled = lowOutput && (repeatedMessage || !changed)
-    if (stalled) {
-      goal.noProgressTurns += 1
-      if (maxNoProgressTurns && goal.noProgressTurns >= maxNoProgressTurns) {
-        accountWallClock(goal)
-        goal.status = "paused"
-        goal.lastAccountedAt = null
-        goal.stopReason = "no progress"
-        goal.blocker = `Auto-continue paused after ${goal.noProgressTurns} low-progress turn(s). Resume the goal to retry.`
-        goal.lastStatus = goal.blocker
-        pushHistory(goal, "warning", goal.blocker)
+    // No-progress accounting is scoped to goal continuation turns: it only runs
+    // once per reserved continuation, when the completed turn is observed at the
+    // next idle. Generic observation paths (messages.transform, message.updated)
+    // record checkpoints above but never touch the counter.
+    const continuationTurnCompleted =
+      input.evaluateContinuation === true &&
+      goal.awaitingContinuationProgress &&
+      Boolean(messageID) &&
+      messageID !== goal.continuationBaselineMessageID
+    if (continuationTurnCompleted) {
+      goal.awaitingContinuationProgress = false
+      const lowOutput = outputTokens > 0 && outputTokens < (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD)
+      const changedSinceContinuation = Boolean(summary && summary !== goal.continuationBaselineSummary)
+      if (lowOutput && !changedSinceContinuation) {
+        goal.noProgressTurns += 1
+        if (maxNoProgressTurns && goal.noProgressTurns >= maxNoProgressTurns) {
+          accountWallClock(goal)
+          goal.status = "paused"
+          goal.lastAccountedAt = null
+          goal.stopReason = "no progress"
+          goal.blocker = `Auto-continue paused after ${goal.noProgressTurns} low-progress continuation turn(s). Resume the goal to retry.`
+          goal.lastStatus = goal.blocker
+          pushHistory(goal, "warning", goal.blocker)
+        } else {
+          goal.lastStatus = `Low-progress continuation turn detected (${goal.noProgressTurns}/${maxNoProgressTurns ?? "unbounded"}).`
+          pushHistory(goal, "warning", goal.lastStatus)
+        }
       } else {
-        goal.lastStatus = `Low-progress turn detected (${goal.noProgressTurns}/${maxNoProgressTurns ?? "unbounded"}).`
-        pushHistory(goal, "warning", goal.lastStatus)
+        goal.noProgressTurns = 0
       }
-    } else if (changed || outputTokens >= (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD)) {
-      goal.noProgressTurns = 0
     }
 
     goal.updatedAt = nowSeconds()
@@ -666,6 +694,9 @@ export async function reserveContinuation(sessionID: string, maxAutoTurns: numbe
     if (goal.lastContinuationAt && now - goal.lastContinuationAt < minIntervalSeconds) return null
     goal.autoTurns += 1
     goal.lastContinuationAt = now
+    goal.awaitingContinuationProgress = true
+    goal.continuationBaselineMessageID = goal.lastAssistantMessageID
+    goal.continuationBaselineSummary = summarizeText(goal.lastAssistantText)
     goal.lastStatus = `Auto-continue ${goal.autoTurns} reserved.`
     pushHistory(goal, "autoContinue", goal.lastStatus)
     goal.updatedAt = now

--- a/src/state.ts
+++ b/src/state.ts
@@ -694,7 +694,9 @@ export async function reserveContinuation(sessionID: string, maxAutoTurns: numbe
     if (goal.lastContinuationAt && now - goal.lastContinuationAt < minIntervalSeconds) return null
     goal.autoTurns += 1
     goal.lastContinuationAt = now
-    goal.awaitingContinuationProgress = true
+    // The baseline is captured at reservation time, but the no-progress
+    // evaluation is only armed once recordContinuationResult confirms the
+    // continuation prompt was actually delivered.
     goal.continuationBaselineMessageID = goal.lastAssistantMessageID
     goal.continuationBaselineSummary = summarizeText(goal.lastAssistantText)
     goal.lastStatus = `Auto-continue ${goal.autoTurns} reserved.`
@@ -712,10 +714,14 @@ export async function recordContinuationResult(sessionID: string, result: "succe
     goal.updatedAt = now
     if (result === "success") {
       goal.continuationFailures = 0
-      if (goal.status === "active") goal.lastStatus = "Auto-continue prompt sent."
+      if (goal.status === "active") {
+        goal.lastStatus = "Auto-continue prompt sent."
+        goal.awaitingContinuationProgress = true
+      }
       return snapshot(goal)
     }
     goal.continuationFailures += 1
+    goal.awaitingContinuationProgress = false
     goal.lastStatus = `Auto-continue failed ${goal.continuationFailures} time(s).`
     pushHistory(goal, "error", goal.lastStatus)
     if (goal.continuationFailures >= maxFailures) {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -517,6 +517,105 @@ test("running task deferral does not record repeated assistant messages as no-pr
   expect(String(read)).toContain('"noProgressTurns": 0')
 })
 
+test("low-output tool-call messages do not pause an active goal without continuations", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false, no_progress_token_threshold: 50, max_no_progress_turns: 2 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "long running goal" }, { sessionID: "ses_1" } as never)
+
+  for (const [id, tokens] of [
+    ["m1", 43],
+    ["m2", 48],
+    ["m3", 15],
+  ] as const) {
+    await hooks["experimental.chat.messages.transform"]!(
+      {},
+      {
+        messages: [
+          {
+            info: { id, role: "assistant", sessionID: "ses_1" },
+            parts: [
+              { type: "text", text: "Checking PTY status." },
+              { type: "step-finish", tokens: { input: 10, output: tokens } },
+            ],
+          },
+        ],
+      } as never,
+    )
+  }
+
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(String(read)).toContain('"status": "active"')
+  expect(String(read)).toContain('"noProgressTurns": 0')
+  expect(String(read)).toContain('"autoTurns": 0')
+})
+
+test("auto-continue pauses only after a low-progress continuation turn", async () => {
+  const calls: unknown[] = []
+  let latest = {
+    info: { id: "m0", role: "assistant", sessionID: "ses_1" },
+    parts: [
+      { type: "text", text: "Initial rich progress" },
+      { type: "step-finish", tokens: { input: 10, output: 200 } },
+    ],
+  }
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+          messages: async () => ({ data: [latest] }),
+        },
+      },
+    } as never,
+    {
+      auto_continue: true,
+      max_auto_turns: 10,
+      min_continue_interval_seconds: 0,
+      no_progress_token_threshold: 50,
+      max_no_progress_turns: 1,
+    },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  expect(calls).toHaveLength(1)
+  const active = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(String(active)).toContain('"status": "active"')
+  expect(String(active)).toContain('"noProgressTurns": 0')
+
+  latest = {
+    info: { id: "m1", role: "assistant", sessionID: "ses_1" },
+    parts: [
+      { type: "text", text: "Initial rich progress" },
+      { type: "step-finish", tokens: { input: 10, output: 10 } },
+    ],
+  }
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  expect(calls).toHaveLength(1)
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(String(read)).toContain('"status": "paused"')
+  expect(String(read)).toContain('"stopReason": "no progress"')
+  expect(String(read)).toContain('"autoTurns": 1')
+  expect(String(read)).toContain("low-progress continuation turn")
+})
+
 test("terminal task waits for orchestrator assistant turn before goal continuation", async () => {
   const calls: unknown[] = []
   const hooks = await plugin.server(

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -11,6 +11,7 @@ import {
   getGoal,
   markGoalUnmet,
   pauseGoalForPlanMode,
+  recordContinuationResult,
   recordPromptAgent,
   reserveContinuation,
   setGoalStatus,
@@ -104,6 +105,7 @@ test("no-progress pause only counts goal continuation turns", async () => {
   await recordAssistantProgress("ses_1", { messageID: "m0", text: "Working on it", outputTokens: 100 })
 
   await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 3)
   const firstStall = await recordAssistantProgress("ses_1", {
     messageID: "m1",
     text: "Working on it",
@@ -114,6 +116,7 @@ test("no-progress pause only counts goal continuation turns", async () => {
   expect(firstStall?.status).toBe("active")
 
   await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 3)
   const paused = await recordAssistantProgress("ses_1", {
     messageID: "m2",
     text: "Working on it",
@@ -130,9 +133,11 @@ test("progressing continuation turns reset the no-progress counter", async () =>
   await recordAssistantProgress("ses_1", { messageID: "m0", text: "Working on it", outputTokens: 100 })
 
   await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 3)
   await recordAssistantProgress("ses_1", { messageID: "m1", text: "Working on it", outputTokens: 10, evaluateContinuation: true })
 
   await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 3)
   const progressed = await recordAssistantProgress("ses_1", {
     messageID: "m2",
     text: "Implemented the parser and added passing tests",
@@ -148,6 +153,7 @@ test("generic observations during a continuation turn do not consume the evaluat
   await createGoal("ses_1", "continue", { noProgressTokenThreshold: 50, maxNoProgressTurns: 2 })
   await recordAssistantProgress("ses_1", { messageID: "m0", text: "Working on it", outputTokens: 100 })
   await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 3)
 
   const observed = await recordAssistantProgress("ses_1", { messageID: "m1", text: "Working on it", outputTokens: 10 })
   expect(observed?.noProgressTurns).toBe(0)
@@ -161,6 +167,26 @@ test("generic observations during a continuation turn do not consume the evaluat
   })
   expect(evaluated?.noProgressTurns).toBe(1)
   expect(evaluated?.awaitingContinuationProgress).toBe(false)
+})
+
+test("failed continuation sends do not arm no-progress evaluation", async () => {
+  await createGoal("ses_1", "continue", { noProgressTokenThreshold: 50, maxNoProgressTurns: 2 })
+  await recordAssistantProgress("ses_1", { messageID: "m0", text: "Checking status", outputTokens: 100 })
+
+  const reserved = await reserveContinuation("ses_1", 10, 0)
+  expect(reserved?.awaitingContinuationProgress).toBe(false)
+
+  const failed = await recordContinuationResult("ses_1", "failure", 3)
+  expect(failed?.awaitingContinuationProgress).toBe(false)
+
+  const observed = await recordAssistantProgress("ses_1", {
+    messageID: "m_user_response",
+    text: "Checking status",
+    outputTokens: 10,
+    evaluateContinuation: true,
+  })
+  expect(observed?.noProgressTurns).toBe(0)
+  expect(observed?.status).toBe("active")
 })
 
 test("creates a paused planning goal and records the prompting agent", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -85,18 +85,82 @@ test("reserves continuation until max auto turns is reached", async () => {
   expect((await getGoal("ses_1"))?.status).toBe("usageLimited")
 })
 
-test("records assistant checkpoints and pauses after repeated no-progress turns", async () => {
+test("generic assistant observations record checkpoints but never pause the goal", async () => {
   await createGoal("ses_1", "continue", { noProgressTokenThreshold: 50, maxNoProgressTurns: 2 })
   const first = await recordAssistantProgress("ses_1", { messageID: "m1", text: "Inspected the repo", outputTokens: 10 })
   expect(first?.lastCheckpoint?.summary).toBe("Inspected the repo")
   expect(first?.status).toBe("active")
 
-  await recordAssistantProgress("ses_1", { messageID: "m1", text: "Inspected the repo", outputTokens: 10 })
-  const paused = await recordAssistantProgress("ses_1", { messageID: "m1", text: "Inspected the repo", outputTokens: 10 })
+  await recordAssistantProgress("ses_1", { messageID: "m2", text: "Checked PTY status", outputTokens: 15 })
+  const observed = await recordAssistantProgress("ses_1", { messageID: "m3", text: "Checked PTY status", outputTokens: 15 })
 
+  expect(observed?.status).toBe("active")
+  expect(observed?.noProgressTurns).toBe(0)
+  expect(observed?.history.some((entry) => entry.type === "checkpoint")).toBe(true)
+})
+
+test("no-progress pause only counts goal continuation turns", async () => {
+  await createGoal("ses_1", "continue", { noProgressTokenThreshold: 50, maxNoProgressTurns: 2 })
+  await recordAssistantProgress("ses_1", { messageID: "m0", text: "Working on it", outputTokens: 100 })
+
+  await reserveContinuation("ses_1", 10, 0)
+  const firstStall = await recordAssistantProgress("ses_1", {
+    messageID: "m1",
+    text: "Working on it",
+    outputTokens: 10,
+    evaluateContinuation: true,
+  })
+  expect(firstStall?.noProgressTurns).toBe(1)
+  expect(firstStall?.status).toBe("active")
+
+  await reserveContinuation("ses_1", 10, 0)
+  const paused = await recordAssistantProgress("ses_1", {
+    messageID: "m2",
+    text: "Working on it",
+    outputTokens: 10,
+    evaluateContinuation: true,
+  })
   expect(paused?.status).toBe("paused")
   expect(paused?.stopReason).toBe("no progress")
-  expect(paused?.history.some((entry) => entry.type === "checkpoint")).toBe(true)
+  expect(paused?.blocker).toContain("continuation turn")
+})
+
+test("progressing continuation turns reset the no-progress counter", async () => {
+  await createGoal("ses_1", "continue", { noProgressTokenThreshold: 50, maxNoProgressTurns: 2 })
+  await recordAssistantProgress("ses_1", { messageID: "m0", text: "Working on it", outputTokens: 100 })
+
+  await reserveContinuation("ses_1", 10, 0)
+  await recordAssistantProgress("ses_1", { messageID: "m1", text: "Working on it", outputTokens: 10, evaluateContinuation: true })
+
+  await reserveContinuation("ses_1", 10, 0)
+  const progressed = await recordAssistantProgress("ses_1", {
+    messageID: "m2",
+    text: "Implemented the parser and added passing tests",
+    outputTokens: 400,
+    evaluateContinuation: true,
+  })
+
+  expect(progressed?.noProgressTurns).toBe(0)
+  expect(progressed?.status).toBe("active")
+})
+
+test("generic observations during a continuation turn do not consume the evaluation", async () => {
+  await createGoal("ses_1", "continue", { noProgressTokenThreshold: 50, maxNoProgressTurns: 2 })
+  await recordAssistantProgress("ses_1", { messageID: "m0", text: "Working on it", outputTokens: 100 })
+  await reserveContinuation("ses_1", 10, 0)
+
+  const observed = await recordAssistantProgress("ses_1", { messageID: "m1", text: "Working on it", outputTokens: 10 })
+  expect(observed?.noProgressTurns).toBe(0)
+  expect(observed?.awaitingContinuationProgress).toBe(true)
+
+  const evaluated = await recordAssistantProgress("ses_1", {
+    messageID: "m1",
+    text: "Working on it",
+    outputTokens: 10,
+    evaluateContinuation: true,
+  })
+  expect(evaluated?.noProgressTurns).toBe(1)
+  expect(evaluated?.awaitingContinuationProgress).toBe(false)
 })
 
 test("creates a paused planning goal and records the prompting agent", async () => {


### PR DESCRIPTION
Closes #5

## Problem

As reported in #5, `noProgressTurns` incremented on **any** low-output assistant message observed through the generic paths (`experimental.chat.messages.transform`, `message.updated`, and the idle path), not just on goal continuation turns. Short tool-call-only turns — PTY status checks, quick tool calls, messages surfaced by other plugins like DCP — could pause an active goal with *"Auto-continue paused after 2 low-progress turn(s)"* even though no continuation prompt had ever been injected and `autoTurns` was still `0`. The same message re-observed by two paths could even count twice.

## Fix (approach 1 from the issue, the reporter's preference)

"Turn" in the no-progress lifecycle now consistently means **goal continuation turn**:

- **`reserveContinuation` captures a baseline** when it reserves a continuation: the last assistant message ID and summary at that moment, plus an `awaitingContinuationProgress` flag on the goal.
- **Exactly one evaluation per reserved continuation.** `recordAssistantProgress` only runs the no-progress logic when called with a new `evaluateContinuation` flag — passed solely by `runAutoContinue` at the next idle, when the continuation's turn has completed. A new completed turn is compared against the reservation baseline: low output tokens **and** an unchanged summary count as one no-progress continuation turn; anything else resets the counter.
- **Generic observation paths never touch the counter.** `messages.transform` and `message.updated` still record checkpoints, last-assistant text/ID, and token usage — but low-output tool-call-only messages can no longer pause a goal. Evaluating against the reservation baseline (not the last observed text) also means partial streaming observations and re-observations cannot double-count or produce false stalls.
- **Multi-step turns are measured fully:** `outputTokensFromMessage` now sums output tokens across all `step-finish` parts instead of returning the first step's count, so a continuation turn that does real work through many small tool steps is not misread as low output.
- **Messages match reality:** pause/warning texts now say *"low-progress continuation turn"*, which is accurate because they can only be produced by continuation turns. README documents the clarified semantics of `no_progress_token_threshold` and `max_no_progress_turns`.

State schema adds `awaitingContinuationProgress`, `continuationBaselineMessageID`, and `continuationBaselineSummary` with backward-compatible defaults; existing state files decode cleanly.

## Regression tests

- The issue's exact scenario: repeated low-output (~43/48/15 output tokens) tool-call assistant messages via `messages.transform` leave the goal `active` with `noProgressTurns: 0` and `autoTurns: 0`.
- End-to-end idle flow: a continuation is sent, its completed turn comes back low-output/unchanged, and only then does the goal pause with `stopReason: "no progress"` — the pause message now references continuation turns.
- State-level: no-progress counting requires a reserved continuation; progressing continuation turns reset the counter; generic observations during a pending continuation neither increment nor consume the one-shot evaluation.

`bun test` (61 pass), `bun run lint`, `bun run typecheck`, and `bun run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)