### PR TITLE
fix: publish tui runtime dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,16 +6,16 @@
       "name": "opencode-goal-plugin",
       "dependencies": {
         "@opencode-ai/plugin": "^1.17.1",
+        "@opentui/solid": "^0.4.0",
         "effect": "^3.21.2",
+        "solid-js": "1.9.12",
         "zod": "^4.1.8",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@opentui/core": "^0.4.0",
-        "@opentui/solid": "^0.4.0",
         "@types/bun": "^1.3.13",
         "eslint": "^10.3.0",
-        "solid-js": "1.9.12",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
       },
@@ -384,7 +384,7 @@
 
     "s-js": ["s-js@0.4.9", "", {}, "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "seroval": ["seroval@1.5.3", "", {}, "sha512-BXe0x4buEeYiIKaRUnth1WqCILQ3k4O67KP/B4pC3pVz0Mv2c96ngA9QDREUYxWY1sb2RZVRqwI9RcpVMyHCVw=="],
 
@@ -438,13 +438,17 @@
 
     "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@opencode-ai/plugin/effect": ["effect@4.0.0-beta.74", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
 

--- a/package.json
+++ b/package.json
@@ -54,16 +54,16 @@
   },
   "dependencies": {
     "@opencode-ai/plugin": "^1.17.1",
+    "@opentui/solid": "^0.4.0",
     "effect": "^3.21.2",
+    "solid-js": "1.9.12",
     "zod": "^4.1.8"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@opentui/core": "^0.4.0",
-    "@opentui/solid": "^0.4.0",
     "@types/bun": "^1.3.13",
     "eslint": "^10.3.0",
-    "solid-js": "1.9.12",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.2"
   },

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+test("published tui entrypoint keeps its runtime imports in dependencies", () => {
+  const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+    dependencies?: Record<string, string>
+    devDependencies?: Record<string, string>
+  }
+
+  const runtimeImports = ["@opentui/solid", "solid-js"]
+
+  for (const dependency of runtimeImports) {
+    expect(packageJson.dependencies?.[dependency]).toBeString()
+    expect(packageJson.devDependencies?.[dependency]).toBeUndefined()
+  }
+})


### PR DESCRIPTION
## What changed

- Moves `@opentui/solid` and `solid-js` from `devDependencies` to `dependencies`.
- Adds a package manifest regression test for the published TUI entrypoint runtime imports.
- Updates `bun.lock` to match the package dependency classification.

## Why

The package publishes `src/tui.tsx` through the `./tui` export. That source file uses the OpenTUI Solid JSX runtime, so consumers that install the published package without dev dependencies need `@opentui/solid` and `solid-js` available at runtime.

I reproduced the install-path failure with a packed tarball before this change:

```sh
pkg=$(npm pack --silent)
tmp=$(mktemp -d)
cp "$pkg" "$tmp/"
(cd "$tmp" && npm init -y >/dev/null && npm install --omit=dev "./$pkg" >/dev/null && bun -e 'import("@prevalentware/opencode-goal-plugin/tui")')
```

Before the fix, that failed with:

```text
Cannot find module '@opentui/solid/jsx-dev-runtime' from .../node_modules/@prevalentware/opencode-goal-plugin/src/tui.tsx
```

After the fix, the same clean packed install/import completes with `import ok`.

## Validation

- `bun test`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run pack:dry-run`
- clean packed install with `npm install --omit=dev` plus `bun -e 'import("@prevalentware/opencode-goal-plugin/tui")'`
