### PR TITLE
Bound automatic continuation retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Defaults:
 - `defer_while_tasks_active`: `true`; when enabled, goal auto-continuation waits for active OpenCode Task child sessions and their orchestrator reconciliation before sending the next goal prompt.
 - `max_auto_turns`: `25`
 - `min_continue_interval_seconds`: `3`
-- `max_turn_time`: unset by default; set a positive number of seconds to retry one active-goal continuation prompt when a model turn remains busy for that long. Each new busy event resets the watchdog. Idle, built-in retry, session deletion, active Task children, and restricted agents suppress the retry. Watchdog retries are independent of `min_continue_interval_seconds` and do not consume auto-turn, no-progress, or prompt-failure budgets.
-- `max_prompt_failures`: `3`
+- `max_turn_time`: unset by default; set a positive number of seconds to retry one active-goal continuation prompt when a model turn remains busy for that long. Each new busy event resets the watchdog. Idle, built-in retry, session deletion, active Task children, and restricted agents suppress the retry. Watchdog retries are independent of `min_continue_interval_seconds` and never consume auto-turn or no-progress budgets, but recognized transport failures still count toward the `max_prompt_failures` ceiling.
+- `max_prompt_failures`: `3`; consecutive transport or no-response continuation failures pause the goal at this ceiling. Prompt delivery alone does not reset the count; substantive assistant or tool progress, a new goal, or an explicit resume does.
 - `default_token_budget`: unset by default; when set, new goals inherit this token budget.
 - `max_goal_duration_seconds`: unset by default; when set, new goals inherit this elapsed-time safety limit.
 - `no_progress_token_threshold`: `50`; output-token floor used to judge whether a goal continuation turn made progress.

--- a/dist/server.js
+++ b/dist/server.js
@@ -34,6 +34,15 @@ var CheckpointSchema = Schema.Struct({
   summary: Schema.String,
   timestamp: Schema.Number
 });
+var PendingAttemptSchema = Schema.Struct({
+  id: Schema.String,
+  reservedAt: Schema.Number,
+  started: Schema.Boolean,
+  delivered: Schema.Boolean,
+  committed: Schema.Boolean,
+  armNoProgress: Schema.Boolean,
+  previousLastContinuationAt: Schema.NullOr(Schema.Number)
+});
 var GoalSchema = Schema.Struct({
   sessionID: Schema.String,
   objective: Schema.String,
@@ -50,8 +59,7 @@ var GoalSchema = Schema.Struct({
   autoTurns: Schema.Number,
   lastContinuationAt: NullableNumber,
   continuationFailures: Schema.optionalWith(Schema.Number, { default: () => 0 }),
-  pendingContinuationStart: Schema.optionalWith(NullableNumber, { default: () => null }),
-  pendingContinuationStarted: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  pendingAttempt: Schema.optionalWith(Schema.NullOr(PendingAttemptSchema), { default: () => null }),
   lastStatus: Schema.optionalWith(NullableString, { default: () => null }),
   maxAutoTurns: Schema.optionalWith(NullableNumber, { default: () => null }),
   maxDurationSeconds: Schema.optionalWith(NullableNumber, { default: () => null }),
@@ -175,8 +183,7 @@ function normalizeGoal(goal) {
   goal.lastPromptAgent ??= null;
   goal.awaitingContinuationProgress = goal.awaitingContinuationProgress === true;
   goal.lastContinuationAt = typeof goal.lastContinuationAt === "number" && Number.isFinite(goal.lastContinuationAt) ? Math.floor(goal.lastContinuationAt >= 1000000000000 ? goal.lastContinuationAt / 1000 : goal.lastContinuationAt) : null;
-  goal.pendingContinuationStart = typeof goal.pendingContinuationStart === "number" && Number.isFinite(goal.pendingContinuationStart) ? goal.pendingContinuationStart : null;
-  goal.pendingContinuationStarted = goal.pendingContinuationStarted === true;
+  goal.pendingAttempt = normalizePendingAttempt(goal.pendingAttempt);
   goal.continuationBaselineMessageID ??= "";
   goal.continuationBaselineSummary ??= "";
   goal.noProgressTurns = nonNegativeInteger(goal.noProgressTurns, 0);
@@ -188,6 +195,22 @@ function normalizeGoal(goal) {
   goal.budgetWrapupSent = goal.budgetWrapupSent === true;
   goal.stopReason ??= null;
   return goal;
+}
+function normalizePendingAttempt(attempt) {
+  if (!attempt || typeof attempt !== "object")
+    return null;
+  return {
+    id: typeof attempt.id === "string" && attempt.id ? attempt.id : randomId(),
+    reservedAt: typeof attempt.reservedAt === "number" && Number.isFinite(attempt.reservedAt) ? attempt.reservedAt : Date.now(),
+    started: attempt.started === true,
+    delivered: attempt.delivered === true,
+    committed: attempt.committed === true,
+    armNoProgress: attempt.armNoProgress !== false,
+    previousLastContinuationAt: typeof attempt.previousLastContinuationAt === "number" && Number.isFinite(attempt.previousLastContinuationAt) ? attempt.previousLastContinuationAt : null
+  };
+}
+function randomId() {
+  return `att_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
 }
 function normalizeCreateOptions(input) {
   if (typeof input === "number" || input === null) {
@@ -244,8 +267,6 @@ function snapshot(goal) {
     blocker: goal.blocker ?? null,
     closedAt: goal.closedAt ?? null,
     continuationFailures: goal.continuationFailures,
-    pendingContinuationStart: goal.pendingContinuationStart,
-    pendingContinuationStarted: goal.pendingContinuationStarted,
     lastStatus: goal.lastStatus,
     maxAutoTurns: goal.maxAutoTurns,
     maxDurationSeconds: goal.maxDurationSeconds,
@@ -269,10 +290,18 @@ function snapshot(goal) {
     sampledAt
   };
 }
+function snapshotInternal(goal) {
+  return { ...snapshot(goal), pendingAttempt: goal.pendingAttempt };
+}
 async function getGoal(sessionID) {
   const state = await readState();
   const goal = state.goals[sessionID];
   return goal ? snapshot(goal) : null;
+}
+async function getGoalInternal(sessionID) {
+  const state = await readState();
+  const goal = state.goals[sessionID];
+  return goal ? snapshotInternal(goal) : null;
 }
 async function createGoal(sessionID, objective, options) {
   const value = validateObjective(objective);
@@ -300,8 +329,7 @@ async function createGoal(sessionID, objective, options) {
       autoTurns: 0,
       lastContinuationAt: null,
       continuationFailures: 0,
-      pendingContinuationStart: null,
-      pendingContinuationStarted: false,
+      pendingAttempt: null,
       lastStatus: paused ? "Goal recorded from Plan mode; execution paused until resumed from Build mode." : "Goal set.",
       maxAutoTurns: normalizedOptions.maxAutoTurns,
       maxDurationSeconds: normalizedOptions.maxDurationSeconds,
@@ -347,8 +375,7 @@ async function updateGoalObjective(sessionID, objective, status = "active", opti
     goal.budgetWrapupSent = false;
     if (goal.status === "active") {
       goal.continuationFailures = 0;
-      goal.pendingContinuationStart = null;
-      goal.pendingContinuationStarted = false;
+      goal.pendingAttempt = null;
       goal.awaitingContinuationProgress = false;
     }
     if (agent)
@@ -402,8 +429,7 @@ async function setGoalStatus(sessionID, status, agent) {
     goal.updatedAt = nowSeconds();
     goal.lastAccountedAt = status === "active" ? goal.updatedAt : null;
     goal.continuationFailures = status === "active" ? 0 : goal.continuationFailures;
-    goal.pendingContinuationStart = status === "active" ? null : goal.pendingContinuationStart;
-    goal.pendingContinuationStarted = status === "active" ? false : goal.pendingContinuationStarted;
+    goal.pendingAttempt = status === "active" ? null : goal.pendingAttempt;
     goal.noProgressTurns = status === "active" ? 0 : goal.noProgressTurns;
     goal.stopReason = status === "active" ? null : "paused";
     goal.budgetWrapupSent = status === "active" ? false : goal.budgetWrapupSent;
@@ -490,15 +516,17 @@ async function recordAssistantProgress(sessionID, input) {
     if (messageID)
       goal.lastAssistantMessageID = messageID;
     if (substantive && summary && (!repeatedMessage || changed)) {
-      goal.continuationFailures = 0;
-      goal.pendingContinuationStart = null;
-      goal.pendingContinuationStarted = false;
+      const attempt = goal.pendingAttempt;
+      if (attempt == null || input.completedAt == null || input.completedAt >= attempt.reservedAt) {
+        goal.continuationFailures = 0;
+        goal.pendingAttempt = null;
+      }
     }
-    const continuationTurnCompleted = input.evaluateContinuation === true && goal.awaitingContinuationProgress && Boolean(messageID) && messageID !== goal.continuationBaselineMessageID;
+    const attemptForCompletion = goal.pendingAttempt;
+    const continuationTurnCompleted = input.evaluateContinuation === true && goal.awaitingContinuationProgress && Boolean(messageID) && messageID !== goal.continuationBaselineMessageID && (input.completedAt == null || attemptForCompletion == null || input.completedAt >= attemptForCompletion.reservedAt);
     if (continuationTurnCompleted) {
       goal.awaitingContinuationProgress = false;
-      goal.pendingContinuationStart = null;
-      goal.pendingContinuationStarted = false;
+      goal.pendingAttempt = null;
       const lowOutput = outputTokens > 0 && outputTokens < (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD);
       const changedSinceContinuation = Boolean(summary && summary !== goal.continuationBaselineSummary);
       if (lowOutput && !changedSinceContinuation) {
@@ -539,38 +567,84 @@ async function reserveContinuation(sessionID, maxAutoTurns, minIntervalSeconds) 
     if (goal.lastContinuationAt && now - goal.lastContinuationAt < minIntervalSeconds)
       return null;
     goal.autoTurns += 1;
+    const previousLastContinuationAt = goal.lastContinuationAt;
     goal.lastContinuationAt = now;
     goal.continuationBaselineMessageID = goal.lastAssistantMessageID;
     goal.continuationBaselineSummary = summarizeText(goal.lastAssistantText);
+    goal.pendingAttempt = {
+      id: randomId(),
+      reservedAt: Date.now(),
+      started: false,
+      delivered: false,
+      committed: true,
+      armNoProgress: true,
+      previousLastContinuationAt
+    };
+    goal.awaitingContinuationProgress = false;
     goal.lastStatus = `Auto-continue ${goal.autoTurns} reserved.`;
     pushHistory(goal, "autoContinue", goal.lastStatus);
     goal.updatedAt = now;
-    return snapshot(goal);
+    return snapshotInternal(goal);
+  });
+}
+async function rollbackContinuationAttempt(sessionID) {
+  return mutate((state) => {
+    const goal = state.goals[sessionID];
+    if (!goal)
+      return false;
+    const attempt = goal.pendingAttempt;
+    if (!attempt || attempt.delivered || !attempt.committed) {
+      if (attempt && !attempt.delivered)
+        goal.pendingAttempt = null;
+      return false;
+    }
+    goal.autoTurns = Math.max(0, goal.autoTurns - 1);
+    goal.lastContinuationAt = attempt.previousLastContinuationAt;
+    goal.pendingAttempt = null;
+    goal.awaitingContinuationProgress = false;
+    goal.lastStatus = "Auto-continue attempt canceled before delivery.";
+    goal.updatedAt = nowSeconds();
+    return true;
   });
 }
 async function recordContinuationResult(sessionID, result, maxFailures, options) {
   return mutate((state) => {
     const goal = state.goals[sessionID];
     if (!goal || isClosed(goal.status))
-      return goal ? snapshot(goal) : null;
+      return goal ? snapshotInternal(goal) : null;
     const now = nowSeconds();
     goal.updatedAt = now;
     if (result === "success") {
       if (goal.status === "active") {
-        goal.pendingContinuationStart = Date.now();
-        goal.pendingContinuationStarted = options?.started === true;
+        const attempt = goal.pendingAttempt;
+        if (attempt) {
+          attempt.delivered = true;
+          attempt.started = attempt.started || options?.started === true;
+          attempt.armNoProgress = options?.armNoProgress ?? attempt.armNoProgress;
+          if (attempt.armNoProgress)
+            goal.awaitingContinuationProgress = true;
+        } else {
+          goal.pendingAttempt = {
+            id: randomId(),
+            reservedAt: Date.now(),
+            started: options?.started === true,
+            delivered: true,
+            committed: false,
+            armNoProgress: options?.armNoProgress !== false,
+            previousLastContinuationAt: goal.lastContinuationAt
+          };
+          if (goal.pendingAttempt.armNoProgress)
+            goal.awaitingContinuationProgress = true;
+        }
         goal.lastStatus = "Auto-continue prompt sent.";
-        if (options?.armNoProgress !== false)
-          goal.awaitingContinuationProgress = true;
       }
-      return snapshot(goal);
+      return snapshotInternal(goal);
     }
-    if (options?.requirePending && goal.pendingContinuationStart == null)
+    if (options?.requirePending && goal.pendingAttempt == null)
       return null;
     goal.continuationFailures += 1;
     goal.awaitingContinuationProgress = false;
-    goal.pendingContinuationStart = null;
-    goal.pendingContinuationStarted = false;
+    goal.pendingAttempt = null;
     goal.lastStatus = `Auto-continue failed ${goal.continuationFailures} time(s).`;
     pushHistory(goal, "error", goal.lastStatus);
     if (goal.continuationFailures >= maxFailures) {
@@ -582,38 +656,44 @@ async function recordContinuationResult(sessionID, result, maxFailures, options)
       goal.blocker = "Auto-continue prompt failed repeatedly. Resume the goal to retry.";
       pushHistory(goal, "paused", goal.lastStatus);
     }
-    return snapshot(goal);
+    return snapshotInternal(goal);
   });
 }
 async function markPendingContinuationStarted(sessionID) {
-  return mutate((state) => {
-    const goal = state.goals[sessionID];
+  const state = await readState();
+  const current = state.goals[sessionID];
+  if (!current || current.status !== "active")
+    return current ? snapshotInternal(current) : null;
+  if (current.pendingAttempt == null || current.pendingAttempt.started)
+    return snapshotInternal(current);
+  return mutate((state2) => {
+    const goal = state2.goals[sessionID];
     if (!goal || goal.status !== "active")
-      return goal ? snapshot(goal) : null;
-    if (goal.pendingContinuationStart == null || goal.pendingContinuationStarted)
-      return snapshot(goal);
-    goal.pendingContinuationStarted = true;
+      return goal ? snapshotInternal(goal) : null;
+    if (goal.pendingAttempt == null || goal.pendingAttempt.started)
+      return snapshotInternal(goal);
+    goal.pendingAttempt.started = true;
     goal.updatedAt = nowSeconds();
-    return snapshot(goal);
+    return snapshotInternal(goal);
   });
 }
-async function recordToolProgress(sessionID, text) {
+async function recordToolProgress(sessionID, text, expectedAttemptID) {
   return mutate((state) => {
     const goal = state.goals[sessionID];
     if (!goal || goal.status !== "active")
-      return goal ? snapshot(goal) : null;
+      return goal ? snapshotInternal(goal) : null;
     const value = text?.trim() ?? "";
     if (!value)
-      return snapshot(goal);
-    if (goal.continuationFailures === 0 && goal.pendingContinuationStart == null)
-      return snapshot(goal);
+      return snapshotInternal(goal);
+    if (goal.continuationFailures === 0 && goal.pendingAttempt == null)
+      return snapshotInternal(goal);
+    if (goal.pendingAttempt != null && expectedAttemptID !== undefined && expectedAttemptID !== goal.pendingAttempt.id) {
+      return snapshotInternal(goal);
+    }
     goal.continuationFailures = 0;
-    goal.pendingContinuationStart = null;
-    goal.pendingContinuationStarted = false;
-    goal.awaitingContinuationProgress = false;
-    goal.noProgressTurns = 0;
+    goal.pendingAttempt = null;
     goal.updatedAt = nowSeconds();
-    return snapshot(goal);
+    return snapshotInternal(goal);
   });
 }
 function reserveWrapup(goal) {
@@ -622,7 +702,7 @@ function reserveWrapup(goal) {
   goal.budgetWrapupSent = true;
   goal.updatedAt = nowSeconds();
   pushHistory(goal, "limited", `${goal.status}: ${goal.stopReason ?? "goal limit reached"}; requested final handoff.`);
-  return snapshot(goal);
+  return snapshotInternal(goal);
 }
 function maybeStopForBudget(goal) {
   if (goal.status !== "active")
@@ -1094,6 +1174,25 @@ function continuationDelayFromSnapshot(minIntervalSeconds, lastContinuationAt, n
     return RETRY_SETTLE_MS;
   return Math.max(0, (lastContinuationAt + minIntervalSeconds + 1) * 1000 - now) + RETRY_SETTLE_MS;
 }
+function pendingAttemptOf(goal) {
+  return goal?.pendingAttempt ?? null;
+}
+function pendingReadyForFailure(attempt, deliveredLocally, now = Date.now()) {
+  if (!attempt)
+    return false;
+  if (attempt.started)
+    return true;
+  if (deliveredLocally)
+    return false;
+  return now - attempt.reservedAt >= STALE_PENDING_MS;
+}
+async function reconcileLocalMarkerAfterProgress(locallyDelivered, sessionID, goal) {
+  if (!goal || goal.continuationFailures !== 0)
+    return;
+  const internal = await getGoalInternal(sessionID);
+  if (internal && internal.pendingAttempt == null)
+    locallyDelivered.delete(sessionID);
+}
 var TOOL_FAILURE_STATES = new Set([
   "failed",
   "failure",
@@ -1436,7 +1535,8 @@ async function recordAssistantMessage(sessionID, message, options, evaluateConti
     outputTokens: outputTokensFromMessage(message) ?? null,
     noProgressTokenThreshold: positiveIntegerOrNull2(options.no_progress_token_threshold),
     maxNoProgressTurns: positiveIntegerOrNull2(options.max_no_progress_turns),
-    evaluateContinuation
+    evaluateContinuation,
+    completedAt: messageCompletedAt(message)
   });
   return { goal, progressed };
 }
@@ -1520,6 +1620,15 @@ function textFromToolResult(result) {
   }
   return;
 }
+function toolAttemptKey(sessionID, callID) {
+  return `${sessionID}\x00${callID}`;
+}
+function clearToolAttemptsForSession(attempts, sessionID) {
+  for (const key of [...attempts.keys()]) {
+    if (key.startsWith(`${sessionID}\x00`))
+      attempts.delete(key);
+  }
+}
 var server = async ({ client }, options) => {
   const autoContinue = options?.auto_continue ?? true;
   const deferWhileTasksActive = options?.defer_while_tasks_active ?? true;
@@ -1536,10 +1645,12 @@ var server = async ({ client }, options) => {
   const busySessions = new Set;
   const nativeRetrySessions = new Set;
   const locallyDeliveredPendingSessions = new Set;
+  const toolAttempts = new Map;
   const watchdogRescuedSessions = new Set;
   const planAgents = restrictedAgentSet(options);
   const isPlanAgent = (agent) => typeof agent === "string" && planAgents.has(agent.trim().toLowerCase());
   const goalServices = { options: options ?? {}, isPlanAgent };
+  let disposed = false;
   async function taskBlockStatus(sessionID) {
     if (!deferWhileTasksActive)
       return false;
@@ -1573,6 +1684,8 @@ var server = async ({ client }, options) => {
   async function runTurnWatchdog(sessionID, watchdog) {
     let claimedContinuation = false;
     try {
+      if (disposed)
+        return;
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID) || watchdogRescuedSessions.has(sessionID))
         return;
       const goal = await getGoal(sessionID);
@@ -1586,7 +1699,8 @@ var server = async ({ client }, options) => {
       const latestTurnAgent = agentFromMessage(latestAssistant);
       if (isPlanAgent(latestTurnAgent))
         return;
-      await recordAssistantMessage(sessionID, latestAssistant, options ?? {});
+      const observedBeforeRescue = await recordAssistantMessage(sessionID, latestAssistant, options ?? {});
+      await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, observedBeforeRescue.goal);
       const taskStatus = await taskBlockStatus(sessionID);
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID))
         return;
@@ -1635,6 +1749,8 @@ var server = async ({ client }, options) => {
     scheduledContinuations.delete(sessionID);
   }
   function scheduleSettledContinuation(sessionID, delayMs = TASK_SETTLE_DELAY_MS, replace = false, purpose = "settle") {
+    if (disposed)
+      return;
     if (!replace && scheduledContinuations.has(sessionID))
       return;
     if (replace)
@@ -1645,8 +1761,8 @@ var server = async ({ client }, options) => {
         if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID))
           return;
         if (purpose === "retry") {
-          const goal = await getGoal(sessionID);
-          if (!goal || goal.continuationFailures === 0 && goal.pendingContinuationStart == null)
+          const goal = await getGoalInternal(sessionID);
+          if (!goal || goal.continuationFailures === 0 && goal.pendingAttempt == null)
             return;
         }
         if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID))
@@ -1665,12 +1781,14 @@ var server = async ({ client }, options) => {
     scheduledContinuations.set(sessionID, scheduled);
   }
   async function runAutoContinue(sessionID, fromTaskDeferral = false, scheduled) {
-    let reservedAt = null;
+    if (disposed)
+      return;
     if (busySessions.has(sessionID))
       return;
     if (activeContinuations.has(sessionID))
       return;
     activeContinuations.add(sessionID);
+    let attemptReservedAt = Date.now();
     try {
       const latestAssistant = await fetchLatestAssistant(client, sessionID);
       taskTracker.observeAssistantMessage(sessionID, latestAssistant);
@@ -1685,12 +1803,13 @@ var server = async ({ client }, options) => {
       if (busySessions.has(sessionID))
         return;
       const observed = await recordAssistantMessage(sessionID, latestAssistant, options ?? {}, true);
+      await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, observed.goal);
       const queued = scheduledContinuations.get(sessionID);
       if (observed.progressed && queued?.purpose !== "settle")
         cancelScheduledContinuation(sessionID);
       if (scheduled && scheduledContinuations.get(sessionID) !== scheduled)
         return;
-      const current = await getGoal(sessionID);
+      const current = await getGoalInternal(sessionID);
       if (!current)
         return;
       const latestTurnAgent = agentFromMessage(latestAssistant);
@@ -1706,10 +1825,10 @@ var server = async ({ client }, options) => {
         return;
       }
       taskDeferredSessions.delete(sessionID);
-      if (current.status === "active" && current.pendingContinuationStart != null) {
-        const pendingAgeMs = Date.now() - current.pendingContinuationStart;
+      const attempt = pendingAttemptOf(current);
+      if (current.status === "active" && attempt != null) {
         const deliveredLocally = locallyDeliveredPendingSessions.has(sessionID);
-        if (!current.pendingContinuationStarted && (deliveredLocally || pendingAgeMs < STALE_PENDING_MS)) {
+        if (!pendingReadyForFailure(attempt, deliveredLocally)) {
           return;
         }
         const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
@@ -1718,7 +1837,7 @@ var server = async ({ client }, options) => {
         if (afterFailure)
           locallyDeliveredPendingSessions.delete(sessionID);
         if (autoContinue && afterFailure?.status === "active") {
-          scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, current.pendingContinuationStart), true, "retry");
+          scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, attempt.reservedAt), true, "retry");
         }
         return;
       }
@@ -1732,18 +1851,37 @@ var server = async ({ client }, options) => {
       const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval);
       if (!goal)
         return;
-      if (nativeRetrySessions.has(sessionID))
+      attemptReservedAt = goal.pendingAttempt?.reservedAt ?? Date.now();
+      if (nativeRetrySessions.has(sessionID)) {
+        await rollbackContinuationAttempt(sessionID);
         return;
-      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled)
+      }
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled) {
+        await rollbackContinuationAttempt(sessionID);
         return;
-      reservedAt = Date.now();
+      }
       await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal), goal.lastPromptAgent ?? latestTurnAgent ?? null);
-      await recordContinuationResult(sessionID, "success", maxPromptFailures);
+      if (disposed) {
+        await rollbackContinuationAttempt(sessionID);
+        return;
+      }
+      const delivered = await recordContinuationResult(sessionID, "success", maxPromptFailures);
       locallyDeliveredPendingSessions.add(sessionID);
+      if (!delivered?.pendingAttempt?.delivered) {
+        await rollbackContinuationAttempt(sessionID);
+      }
     } catch (error) {
-      const afterFailure = reservedAt == null ? null : await recordContinuationResult(sessionID, "failure", maxPromptFailures);
-      if (isTransportError(error) && autoContinue && reservedAt != null && afterFailure?.status === "active") {
-        scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, reservedAt), true, "retry");
+      if (disposed) {
+        await rollbackContinuationAttempt(sessionID);
+        return;
+      }
+      if (isTransportError(error)) {
+        const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures);
+        if (autoContinue && afterFailure?.status === "active") {
+          scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, attemptReservedAt), true, "retry");
+        }
+      } else {
+        await rollbackContinuationAttempt(sessionID);
       }
       await client.app?.log?.({
         body: {
@@ -1759,6 +1897,7 @@ var server = async ({ client }, options) => {
   }
   return {
     async dispose() {
+      disposed = true;
       for (const scheduled of scheduledContinuations.values())
         clearTimeout(scheduled.timer);
       scheduledContinuations.clear();
@@ -1768,6 +1907,7 @@ var server = async ({ client }, options) => {
       watchdogRescuedSessions.clear();
       locallyDeliveredPendingSessions.clear();
       nativeRetrySessions.clear();
+      toolAttempts.clear();
     },
     async config(config) {
       if (!registerCommand)
@@ -1854,10 +1994,21 @@ var server = async ({ client }, options) => {
     },
     async "tool.execute.before"(input) {
       taskTracker.noteTaskCall(input);
+      const sessionID = typeof input?.sessionID === "string" ? input.sessionID : undefined;
+      const callID = typeof input?.callID === "string" ? input.callID : undefined;
+      if (sessionID && callID) {
+        const goal = await getGoalInternal(sessionID);
+        toolAttempts.set(toolAttemptKey(sessionID, callID), goal?.pendingAttempt?.id ?? null);
+      }
     },
     async "tool.execute.after"(input, output) {
       taskTracker.noteTaskOutput(input, output);
       const sessionID = typeof input?.sessionID === "string" ? input.sessionID : undefined;
+      const callID = typeof input?.callID === "string" ? input.callID : undefined;
+      const attemptKey = sessionID && callID ? toolAttemptKey(sessionID, callID) : undefined;
+      const expectedAttemptID = attemptKey ? toolAttempts.get(attemptKey) : undefined;
+      if (attemptKey)
+        toolAttempts.delete(attemptKey);
       if (!sessionID)
         return;
       if (typeof input?.tool === "string" && NON_PROGRESS_TOOLS.has(input.tool.toLowerCase()))
@@ -1868,13 +2019,13 @@ var server = async ({ client }, options) => {
       const text = typeof toolResult.output === "string" ? toolResult.output : undefined;
       if (!text)
         return;
-      const before = await getGoal(sessionID);
+      const before = await getGoalInternal(sessionID);
       const scheduled = scheduledContinuations.get(sessionID);
-      const hasFailureEpisode = Boolean(before && (before.continuationFailures > 0 || before.pendingContinuationStart != null));
+      const hasFailureEpisode = Boolean(before && (before.continuationFailures > 0 || before.pendingAttempt != null));
       if (!before || !hasFailureEpisode && scheduled?.purpose !== "recovery")
         return;
-      const progressed = await recordToolProgress(sessionID, text);
-      if (progressed?.continuationFailures === 0 && progressed.pendingContinuationStart == null) {
+      const progressed = await recordToolProgress(sessionID, text, expectedAttemptID);
+      if (progressed?.continuationFailures === 0 && progressed.pendingAttempt == null) {
         locallyDeliveredPendingSessions.delete(sessionID);
         cancelScheduledContinuation(sessionID);
       }
@@ -1893,6 +2044,7 @@ var server = async ({ client }, options) => {
         return;
       await accountUsage(sessionID, tokensFromMessages(output.messages));
       const observed = await recordAssistantMessage(sessionID, latestAssistantMessage(output.messages), options ?? {});
+      await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, observed.goal);
       const scheduled = scheduledContinuations.get(sessionID);
       if (observed.progressed && scheduled?.purpose !== "settle")
         cancelScheduledContinuation(sessionID);
@@ -1952,23 +2104,27 @@ var server = async ({ client }, options) => {
         taskTracker.observeSessionStatus(sessionID, "idle");
       }
       if (sessionID && eventType === "session.error") {
+        const inNativeRetry = nativeRetrySessions.has(sessionID);
         busySessions.delete(sessionID);
-        nativeRetrySessions.delete(sessionID);
         clearTurnWatchdog(sessionID);
+        if (inNativeRetry)
+          return;
+        nativeRetrySessions.delete(sessionID);
         watchdogRescuedSessions.delete(sessionID);
         const props = event.properties ?? {};
         const errorMessage = transportErrorMessageFromEvent(props);
         if (errorMessage && isTransportError(errorMessage)) {
-          const goal = await getGoal(sessionID);
+          const goal = await getGoalInternal(sessionID);
           if (goal?.status === "active") {
-            if (goal.pendingContinuationStart != null) {
+            const attempt = pendingAttemptOf(goal);
+            if (attempt != null) {
               const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
                 requirePending: true
               });
               if (afterFailure)
                 locallyDeliveredPendingSessions.delete(sessionID);
               if (autoContinue && afterFailure?.status === "active") {
-                scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, goal.pendingContinuationStart), true, "retry");
+                scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, attempt.reservedAt), true, "retry");
               }
             } else if (autoContinue) {
               scheduleSettledContinuation(sessionID, continuationDelayFromSnapshot(minInterval, goal.lastContinuationAt), false, "recovery");
@@ -1984,6 +2140,7 @@ var server = async ({ client }, options) => {
         nativeRetrySessions.delete(sessionID);
         cancelScheduledContinuation(sessionID);
         taskDeferredSessions.delete(sessionID);
+        clearToolAttemptsForSession(toolAttempts, sessionID);
         taskTracker.observeSessionDeleted(sessionID);
       }
       if (sessionID && event.type === "message.updated") {
@@ -1991,6 +2148,7 @@ var server = async ({ client }, options) => {
         const message = [props.info, props.message].find((value) => value && typeof value === "object");
         taskTracker.observeAssistantMessage(sessionID, message);
         const observed = await recordAssistantMessage(sessionID, message, options ?? {});
+        await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, observed.goal);
         const scheduled = scheduledContinuations.get(sessionID);
         if (observed.progressed && scheduled?.purpose !== "settle")
           cancelScheduledContinuation(sessionID);
@@ -1999,7 +2157,7 @@ var server = async ({ client }, options) => {
         return;
       if (!sessionID)
         return;
-      if (!autoContinue && (await getGoal(sessionID))?.pendingContinuationStart == null)
+      if (!autoContinue && (await getGoalInternal(sessionID))?.pendingAttempt == null)
         return;
       await runAutoContinue(sessionID);
     }
@@ -2015,7 +2173,7 @@ async function setupV2(context) {
   const autoContinue = options.auto_continue ?? true;
   const deferWhileTasksActive = options.defer_while_tasks_active ?? true;
   const maxAutoTurns = positiveIntegerOrNull2(options.max_auto_turns) ?? DEFAULT_MAX_AUTO_TURNS;
-  const minInterval = positiveIntegerOrNull2(options.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS;
+  const minInterval = nonNegativeIntegerOrNull(options.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS;
   const maxTurnTimeMs = timeoutMillisecondsFromSeconds(options.max_turn_time);
   const maxPromptFailures = positiveIntegerOrNull2(options.max_prompt_failures) ?? DEFAULT_MAX_PROMPT_FAILURES;
   const registerCommand = options.register_command ?? true;
@@ -2025,6 +2183,10 @@ async function setupV2(context) {
   const scheduledContinuations = new Map;
   const turnWatchdogs = new Map;
   const busySessions = new Set;
+  const nativeRetrySessions = new Set;
+  const locallyDeliveredPendingSessions = new Set;
+  const watchdogRescuedSessions = new Set;
+  const toolAttempts = new Map;
   const planAgents = restrictedAgentSet(options);
   const isPlanAgent = (agent) => typeof agent === "string" && planAgents.has(agent.trim().toLowerCase());
   const goalServices = { options, isPlanAgent };
@@ -2033,6 +2195,7 @@ async function setupV2(context) {
   const stepTextBuffers = new Map;
   const stepTokenSums = new Map;
   const registrations = [];
+  let disposed = false;
   function stepKey(sessionID, messageID2) {
     return `${sessionID}\x00${messageID2}`;
   }
@@ -2061,6 +2224,8 @@ async function setupV2(context) {
   function armTurnWatchdog(sessionID) {
     if (maxTurnTimeMs == null)
       return;
+    if (watchdogRescuedSessions.has(sessionID))
+      return;
     clearTurnWatchdog(sessionID);
     const watchdog = {
       timer: setTimeout(() => void runTurnWatchdog(sessionID, watchdog), maxTurnTimeMs)
@@ -2073,7 +2238,9 @@ async function setupV2(context) {
   async function runTurnWatchdog(sessionID, watchdog) {
     let claimedContinuation = false;
     try {
-      if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID))
+      if (disposed)
+        return;
+      if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID) || watchdogRescuedSessions.has(sessionID))
         return;
       const goal = await getGoal(sessionID);
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID))
@@ -2088,7 +2255,7 @@ async function setupV2(context) {
         return;
       if (taskStatus && taskStatus.blocked)
         return;
-      const current = await getGoal(sessionID);
+      const current = await getGoalInternal(sessionID);
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID))
         return;
       if (current?.status !== "active" || isPlanAgent(current.lastPromptAgent) || activeContinuationsV2.has(sessionID))
@@ -2096,9 +2263,20 @@ async function setupV2(context) {
       turnWatchdogs.delete(sessionID);
       activeContinuationsV2.add(sessionID);
       claimedContinuation = true;
+      watchdogRescuedSessions.add(sessionID);
       await sendContinuation2(sessionID, continuationPrompt(current), current.lastPromptAgent ?? latestStep?.agent ?? null);
+      await recordContinuationResult(sessionID, "success", maxPromptFailures, { armNoProgress: false, started: true });
+      locallyDeliveredPendingSessions.add(sessionID);
+      clearTurnWatchdog(sessionID);
     } catch (error) {
-      v2ErrorLog("Turn watchdog retry failed", error);
+      try {
+        if (claimedContinuation && isTransportError(error)) {
+          await recordContinuationResult(sessionID, "failure", maxPromptFailures);
+        }
+        v2ErrorLog("Turn watchdog retry failed", error);
+      } catch {
+        return;
+      }
     } finally {
       if (claimedContinuation)
         activeContinuationsV2.delete(sessionID);
@@ -2106,24 +2284,53 @@ async function setupV2(context) {
         turnWatchdogs.delete(sessionID);
     }
   }
-  function scheduleSettledContinuation(sessionID, delayMs = TASK_SETTLE_DELAY_MS) {
-    if (scheduledContinuations.has(sessionID))
+  function cancelScheduledContinuation(sessionID) {
+    const scheduled = scheduledContinuations.get(sessionID);
+    if (scheduled)
+      clearTimeout(scheduled.timer);
+    scheduledContinuations.delete(sessionID);
+  }
+  function scheduleSettledContinuation(sessionID, delayMs = TASK_SETTLE_DELAY_MS, replace = false, purpose = "settle") {
+    if (disposed)
       return;
-    const timer = setTimeout(() => {
-      scheduledContinuations.delete(sessionID);
-      runAutoContinue(sessionID, true);
+    if (!replace && scheduledContinuations.has(sessionID))
+      return;
+    if (replace)
+      cancelScheduledContinuation(sessionID);
+    const scheduled = {};
+    const timer = setTimeout(async () => {
+      try {
+        if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID))
+          return;
+        if (purpose === "retry") {
+          const goal = await getGoalInternal(sessionID);
+          if (!goal || goal.continuationFailures === 0 && goal.pendingAttempt == null)
+            return;
+        }
+        if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID))
+          return;
+        await runAutoContinue(sessionID, true, scheduled);
+      } finally {
+        if (scheduledContinuations.get(sessionID) === scheduled)
+          scheduledContinuations.delete(sessionID);
+      }
     }, Math.max(0, delayMs));
+    scheduled.timer = timer;
+    scheduled.purpose = purpose;
     const maybeUnref = timer;
     if (typeof maybeUnref.unref === "function")
       maybeUnref.unref();
-    scheduledContinuations.set(sessionID, timer);
+    scheduledContinuations.set(sessionID, scheduled);
   }
-  async function runAutoContinue(sessionID, fromTaskDeferral = false) {
+  async function runAutoContinue(sessionID, fromTaskDeferral = false, scheduled) {
+    if (disposed)
+      return;
     if (busySessions.has(sessionID))
       return;
     if (activeContinuationsV2.has(sessionID))
       return;
     activeContinuationsV2.add(sessionID);
+    let attemptReservedAt = Date.now();
     try {
       const latestStep = latestStepBySession.get(sessionID);
       if (latestStep?.messageID) {
@@ -2132,23 +2339,33 @@ async function setupV2(context) {
       const taskStatus = taskBlockStatus(sessionID);
       if (taskStatus && taskStatus.blocked) {
         taskDeferredSessions.add(sessionID);
-        if (taskStatus.retryAt != null)
-          scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now());
+        if (taskStatus.retryAt != null) {
+          scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now(), scheduled != null);
+        }
         return;
       }
       if (busySessions.has(sessionID))
         return;
       if (latestStep) {
-        await recordAssistantProgress(sessionID, {
+        const beforeProgress = await getGoalInternal(sessionID);
+        const after = await recordAssistantProgress(sessionID, {
           messageID: latestStep.messageID,
           text: latestStep.text,
           outputTokens: latestStep.outputTokens,
           noProgressTokenThreshold: positiveIntegerOrNull2(options.no_progress_token_threshold),
           maxNoProgressTurns: positiveIntegerOrNull2(options.max_no_progress_turns),
-          evaluateContinuation: true
+          evaluateContinuation: true,
+          completedAt: latestStep.completedAt
         });
+        await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, after);
+        const progressed = Boolean(after && (after.lastAssistantMessageID !== (beforeProgress?.lastAssistantMessageID ?? "") || after.lastAssistantText !== (beforeProgress?.lastAssistantText ?? "")));
+        const queuedAfterProgress = scheduledContinuations.get(sessionID);
+        if (progressed && queuedAfterProgress?.purpose !== "settle")
+          cancelScheduledContinuation(sessionID);
       }
-      const current = await getGoal(sessionID);
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled)
+        return;
+      const current = await getGoalInternal(sessionID);
       if (!current)
         return;
       const latestTurnAgent = latestStep?.agent;
@@ -2164,13 +2381,64 @@ async function setupV2(context) {
         return;
       }
       taskDeferredSessions.delete(sessionID);
+      const attempt = pendingAttemptOf(current);
+      if (current.status === "active" && attempt != null) {
+        const deliveredLocally = locallyDeliveredPendingSessions.has(sessionID);
+        if (!pendingReadyForFailure(attempt, deliveredLocally)) {
+          return;
+        }
+        const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
+          requirePending: true
+        });
+        if (afterFailure)
+          locallyDeliveredPendingSessions.delete(sessionID);
+        if (autoContinue && afterFailure?.status === "active") {
+          scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, attempt.reservedAt), true, "retry");
+        }
+        return;
+      }
+      const queuedBeforeReserve = scheduledContinuations.get(sessionID);
+      if (queuedBeforeReserve && queuedBeforeReserve !== scheduled)
+        return;
+      if (!autoContinue)
+        return;
+      if (nativeRetrySessions.has(sessionID))
+        return;
       const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval);
       if (!goal)
         return;
+      attemptReservedAt = goal.pendingAttempt?.reservedAt ?? Date.now();
+      if (nativeRetrySessions.has(sessionID)) {
+        await rollbackContinuationAttempt(sessionID);
+        return;
+      }
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled) {
+        await rollbackContinuationAttempt(sessionID);
+        return;
+      }
       await sendContinuation2(sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal), goal.lastPromptAgent ?? latestTurnAgent ?? null);
-      await recordContinuationResult(sessionID, "success", maxPromptFailures);
+      if (disposed) {
+        await rollbackContinuationAttempt(sessionID);
+        return;
+      }
+      const delivered = await recordContinuationResult(sessionID, "success", maxPromptFailures);
+      locallyDeliveredPendingSessions.add(sessionID);
+      if (!delivered?.pendingAttempt?.delivered) {
+        await rollbackContinuationAttempt(sessionID);
+      }
     } catch (error) {
-      await recordContinuationResult(sessionID, "failure", maxPromptFailures);
+      if (disposed) {
+        await rollbackContinuationAttempt(sessionID);
+        return;
+      }
+      if (isTransportError(error)) {
+        const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures);
+        if (autoContinue && afterFailure?.status === "active") {
+          scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, attemptReservedAt), true, "retry");
+        }
+      } else {
+        await rollbackContinuationAttempt(sessionID);
+      }
       v2ErrorLog("Auto-continue failed", error);
     } finally {
       activeContinuationsV2.delete(sessionID);
@@ -2190,31 +2458,76 @@ async function setupV2(context) {
       case "session.status": {
         const status = data.status;
         if (sessionID && isRecord(status) && typeof status.type === "string") {
-          if (status.type === "busy")
+          if (status.type === "busy") {
             busySessions.add(sessionID);
-          if (status.type === "busy")
+            nativeRetrySessions.delete(sessionID);
             armTurnWatchdog(sessionID);
+            await markPendingContinuationStarted(sessionID);
+          }
           if (status.type === "idle") {
             busySessions.delete(sessionID);
+            nativeRetrySessions.delete(sessionID);
             clearTurnWatchdog(sessionID);
+            watchdogRescuedSessions.delete(sessionID);
           }
-          if (status.type === "retry")
+          if (status.type === "retry") {
+            nativeRetrySessions.add(sessionID);
             clearTurnWatchdog(sessionID);
+            cancelScheduledContinuation(sessionID);
+          }
           taskTracker.observeSessionStatus(sessionID, status.type);
-        }
-        if (autoContinue && sessionID && isRecord(status) && status.type === "idle") {
-          await runAutoContinue(sessionID);
+          if (status.type === "idle") {
+            const goal = await getGoalInternal(sessionID);
+            if (autoContinue || goal?.pendingAttempt != null)
+              await runAutoContinue(sessionID);
+          }
         }
         return;
       }
       case "session.idle": {
         if (sessionID) {
           busySessions.delete(sessionID);
+          nativeRetrySessions.delete(sessionID);
           clearTurnWatchdog(sessionID);
+          watchdogRescuedSessions.delete(sessionID);
           taskTracker.observeSessionStatus(sessionID, "idle");
         }
-        if (autoContinue && sessionID)
-          await runAutoContinue(sessionID);
+        if (sessionID) {
+          const goal = await getGoalInternal(sessionID);
+          if (autoContinue || goal?.pendingAttempt != null)
+            await runAutoContinue(sessionID);
+        }
+        return;
+      }
+      case "session.error": {
+        if (!sessionID)
+          return;
+        const inNativeRetry = nativeRetrySessions.has(sessionID);
+        busySessions.delete(sessionID);
+        clearTurnWatchdog(sessionID);
+        if (inNativeRetry)
+          return;
+        nativeRetrySessions.delete(sessionID);
+        watchdogRescuedSessions.delete(sessionID);
+        const errorMessage = transportErrorMessageFromEvent(data);
+        if (errorMessage && isTransportError(errorMessage)) {
+          const goal = await getGoalInternal(sessionID);
+          if (goal?.status === "active") {
+            const attempt = pendingAttemptOf(goal);
+            if (attempt != null) {
+              const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
+                requirePending: true
+              });
+              if (afterFailure)
+                locallyDeliveredPendingSessions.delete(sessionID);
+              if (autoContinue && afterFailure?.status === "active") {
+                scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, attempt.reservedAt), true, "retry");
+              }
+            } else if (autoContinue) {
+              scheduleSettledContinuation(sessionID, continuationDelayFromSnapshot(minInterval, goal.lastContinuationAt), false, "recovery");
+            }
+          }
+        }
         return;
       }
       case "session.deleted": {
@@ -2222,11 +2535,15 @@ async function setupV2(context) {
           return;
         busySessions.delete(sessionID);
         clearTurnWatchdog(sessionID);
+        watchdogRescuedSessions.delete(sessionID);
+        locallyDeliveredPendingSessions.delete(sessionID);
+        nativeRetrySessions.delete(sessionID);
         const scheduled = scheduledContinuations.get(sessionID);
         if (scheduled)
-          clearTimeout(scheduled);
+          clearTimeout(scheduled.timer);
         scheduledContinuations.delete(sessionID);
         taskDeferredSessions.delete(sessionID);
+        clearToolAttemptsForSession(toolAttempts, sessionID);
         taskTracker.observeSessionDeleted(sessionID);
         latestStepBySession.delete(sessionID);
         stepTokenSums.delete(sessionID);
@@ -2253,7 +2570,7 @@ async function setupV2(context) {
         });
         if (!stepTextBuffers.has(stepKey(sessionID, messageID2)))
           stepTextBuffers.set(stepKey(sessionID, messageID2), "");
-        latestStepBySession.set(sessionID, { messageID: messageID2, agent, text: "", outputTokens: null });
+        latestStepBySession.set(sessionID, { messageID: messageID2, agent, text: "", outputTokens: null, completedAt: event.created });
         return;
       }
       case "session.text.delta": {
@@ -2282,18 +2599,26 @@ async function setupV2(context) {
         const text = stepTextBuffers.get(stepKey(sessionID, messageID2)) ?? "";
         stepTextBuffers.delete(stepKey(sessionID, messageID2));
         const outputTokens = outputTokensFromRecord(data.tokens) ?? null;
-        await recordAssistantProgress(sessionID, {
+        const afterStep = await recordAssistantProgress(sessionID, {
           messageID: messageID2,
           text,
           outputTokens,
           noProgressTokenThreshold: positiveIntegerOrNull2(options.no_progress_token_threshold),
-          maxNoProgressTurns: positiveIntegerOrNull2(options.max_no_progress_turns)
+          maxNoProgressTurns: positiveIntegerOrNull2(options.max_no_progress_turns),
+          completedAt: event.created
         });
+        await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, afterStep);
+        if (/[\p{L}\p{N}]/u.test(text)) {
+          const scheduled = scheduledContinuations.get(sessionID);
+          if (scheduled?.purpose === "recovery")
+            cancelScheduledContinuation(sessionID);
+        }
         latestStepBySession.set(sessionID, {
           messageID: messageID2,
           agent: latestStepBySession.get(sessionID)?.agent,
           text,
-          outputTokens
+          outputTokens,
+          completedAt: event.created
         });
         return;
       }
@@ -2310,18 +2635,26 @@ async function setupV2(context) {
         const text = stepTextBuffers.get(stepKey(sessionID, messageID2)) ?? "";
         stepTextBuffers.delete(stepKey(sessionID, messageID2));
         const outputTokens = outputTokensFromRecord(data.tokens) ?? null;
-        await recordAssistantProgress(sessionID, {
+        const afterStep = await recordAssistantProgress(sessionID, {
           messageID: messageID2,
           text,
           outputTokens,
           noProgressTokenThreshold: positiveIntegerOrNull2(options.no_progress_token_threshold),
-          maxNoProgressTurns: positiveIntegerOrNull2(options.max_no_progress_turns)
+          maxNoProgressTurns: positiveIntegerOrNull2(options.max_no_progress_turns),
+          completedAt: event.created
         });
+        await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, afterStep);
+        if (/[\p{L}\p{N}]/u.test(text)) {
+          const scheduled = scheduledContinuations.get(sessionID);
+          if (scheduled?.purpose === "recovery")
+            cancelScheduledContinuation(sessionID);
+        }
         latestStepBySession.set(sessionID, {
           messageID: messageID2,
           agent: latestStepBySession.get(sessionID)?.agent,
           text,
-          outputTokens
+          outputTokens,
+          completedAt: event.created
         });
         return;
       }
@@ -2349,13 +2682,44 @@ async function setupV2(context) {
     for (const tool of goalToolsV2(goalServices))
       draft.add(tool);
   }));
-  registrations.push(await context.tool.hook("execute.before", (input) => {
+  registrations.push(await context.tool.hook("execute.before", async (input) => {
     taskTracker.noteTaskCall({ tool: input.tool, sessionID: input.sessionID, callID: input.id });
+    const sessionID = typeof input.sessionID === "string" ? input.sessionID : undefined;
+    const callID = typeof input.id === "string" ? input.id : undefined;
+    if (sessionID && callID) {
+      const goal = await getGoalInternal(sessionID);
+      toolAttempts.set(toolAttemptKey(sessionID, callID), goal?.pendingAttempt?.id ?? null);
+    }
   }));
-  registrations.push(await context.tool.hook("execute.after", (input) => {
+  registrations.push(await context.tool.hook("execute.after", async (input) => {
+    const sessionID = typeof input.sessionID === "string" ? input.sessionID : undefined;
+    const callID = typeof input.id === "string" ? input.id : undefined;
+    const attemptKey = sessionID && callID ? toolAttemptKey(sessionID, callID) : undefined;
+    const expectedAttemptID = attemptKey ? toolAttempts.get(attemptKey) : undefined;
+    if (attemptKey)
+      toolAttempts.delete(attemptKey);
     if (input.status !== "completed")
       return;
+    const text = textFromToolResult(input.result);
     taskTracker.noteTaskOutput({ tool: input.tool, sessionID: input.sessionID, callID: input.id }, { output: textFromToolResult(input.result) });
+    if (!sessionID || typeof input.tool !== "string")
+      return;
+    if (NON_PROGRESS_TOOLS.has(input.tool.toLowerCase()))
+      return;
+    if (toolOutputFailed(input.result))
+      return;
+    if (!text)
+      return;
+    const before = await getGoalInternal(sessionID);
+    const scheduled = scheduledContinuations.get(sessionID);
+    const hasFailureEpisode = Boolean(before && (before.continuationFailures > 0 || before.pendingAttempt != null));
+    if (!before || !hasFailureEpisode && scheduled?.purpose !== "recovery")
+      return;
+    const progressed = await recordToolProgress(sessionID, text, expectedAttemptID);
+    if (progressed?.continuationFailures === 0 && progressed.pendingAttempt == null) {
+      locallyDeliveredPendingSessions.delete(sessionID);
+      cancelScheduledContinuation(sessionID);
+    }
   }));
   registrations.push(await context.session.hook("context", (sessionContext) => {
     const reminder = systemReminder();
@@ -2382,14 +2746,19 @@ async function setupV2(context) {
     }
   })();
   return async () => {
+    disposed = true;
     abortController.abort();
-    for (const timer of scheduledContinuations.values())
-      clearTimeout(timer);
+    for (const scheduled of scheduledContinuations.values())
+      clearTimeout(scheduled.timer);
     scheduledContinuations.clear();
     for (const watchdog of turnWatchdogs.values())
       clearTimeout(watchdog.timer);
     turnWatchdogs.clear();
     activeContinuationsV2.clear();
+    nativeRetrySessions.clear();
+    locallyDeliveredPendingSessions.clear();
+    watchdogRescuedSessions.clear();
+    toolAttempts.clear();
     for (const registration of registrations)
       await registration.dispose();
     const termination = Promise.allSettled([consumer, eventIterator?.return?.()]);

--- a/dist/server.js
+++ b/dist/server.js
@@ -50,6 +50,8 @@ var GoalSchema = Schema.Struct({
   autoTurns: Schema.Number,
   lastContinuationAt: NullableNumber,
   continuationFailures: Schema.optionalWith(Schema.Number, { default: () => 0 }),
+  pendingContinuationStart: Schema.optionalWith(NullableNumber, { default: () => null }),
+  pendingContinuationStarted: Schema.optionalWith(Schema.Boolean, { default: () => false }),
   lastStatus: Schema.optionalWith(NullableString, { default: () => null }),
   maxAutoTurns: Schema.optionalWith(NullableNumber, { default: () => null }),
   maxDurationSeconds: Schema.optionalWith(NullableNumber, { default: () => null }),
@@ -172,6 +174,9 @@ function normalizeGoal(goal) {
   goal.lastAssistantMessageID ??= "";
   goal.lastPromptAgent ??= null;
   goal.awaitingContinuationProgress = goal.awaitingContinuationProgress === true;
+  goal.lastContinuationAt = typeof goal.lastContinuationAt === "number" && Number.isFinite(goal.lastContinuationAt) ? Math.floor(goal.lastContinuationAt >= 1000000000000 ? goal.lastContinuationAt / 1000 : goal.lastContinuationAt) : null;
+  goal.pendingContinuationStart = typeof goal.pendingContinuationStart === "number" && Number.isFinite(goal.pendingContinuationStart) ? goal.pendingContinuationStart : null;
+  goal.pendingContinuationStarted = goal.pendingContinuationStarted === true;
   goal.continuationBaselineMessageID ??= "";
   goal.continuationBaselineSummary ??= "";
   goal.noProgressTurns = nonNegativeInteger(goal.noProgressTurns, 0);
@@ -239,6 +244,8 @@ function snapshot(goal) {
     blocker: goal.blocker ?? null,
     closedAt: goal.closedAt ?? null,
     continuationFailures: goal.continuationFailures,
+    pendingContinuationStart: goal.pendingContinuationStart,
+    pendingContinuationStarted: goal.pendingContinuationStarted,
     lastStatus: goal.lastStatus,
     maxAutoTurns: goal.maxAutoTurns,
     maxDurationSeconds: goal.maxDurationSeconds,
@@ -293,6 +300,8 @@ async function createGoal(sessionID, objective, options) {
       autoTurns: 0,
       lastContinuationAt: null,
       continuationFailures: 0,
+      pendingContinuationStart: null,
+      pendingContinuationStarted: false,
       lastStatus: paused ? "Goal recorded from Plan mode; execution paused until resumed from Build mode." : "Goal set.",
       maxAutoTurns: normalizedOptions.maxAutoTurns,
       maxDurationSeconds: normalizedOptions.maxDurationSeconds,
@@ -336,6 +345,12 @@ async function updateGoalObjective(sessionID, objective, status = "active", opti
     goal.closedAt = null;
     goal.stopReason = planModePause ? PLAN_MODE_STOP_REASON : null;
     goal.budgetWrapupSent = false;
+    if (goal.status === "active") {
+      goal.continuationFailures = 0;
+      goal.pendingContinuationStart = null;
+      goal.pendingContinuationStarted = false;
+      goal.awaitingContinuationProgress = false;
+    }
     if (agent)
       goal.lastPromptAgent = agent;
     goal.lastStatus = planModePause ? "Goal objective updated; execution paused while the session is in Plan mode." : goal.status === "active" ? "Goal objective updated and resumed." : "Goal objective updated and paused.";
@@ -387,6 +402,8 @@ async function setGoalStatus(sessionID, status, agent) {
     goal.updatedAt = nowSeconds();
     goal.lastAccountedAt = status === "active" ? goal.updatedAt : null;
     goal.continuationFailures = status === "active" ? 0 : goal.continuationFailures;
+    goal.pendingContinuationStart = status === "active" ? null : goal.pendingContinuationStart;
+    goal.pendingContinuationStarted = status === "active" ? false : goal.pendingContinuationStarted;
     goal.noProgressTurns = status === "active" ? 0 : goal.noProgressTurns;
     goal.stopReason = status === "active" ? null : "paused";
     goal.budgetWrapupSent = status === "active" ? false : goal.budgetWrapupSent;
@@ -462,6 +479,7 @@ async function recordAssistantProgress(sessionID, input) {
     const threshold = positiveIntegerOrNull(input.noProgressTokenThreshold) ?? goal.noProgressTokenThreshold;
     const maxNoProgressTurns = positiveIntegerOrNull(input.maxNoProgressTurns) ?? goal.maxNoProgressTurns;
     const summary = summarizeText(text);
+    const substantive = /[\p{L}\p{N}]/u.test(text);
     const previousSummary = summarizeText(goal.lastAssistantText);
     const repeatedMessage = Boolean(messageID && messageID === goal.lastAssistantMessageID);
     const changed = Boolean(summary && summary !== previousSummary);
@@ -471,9 +489,16 @@ async function recordAssistantProgress(sessionID, input) {
       goal.lastAssistantText = text;
     if (messageID)
       goal.lastAssistantMessageID = messageID;
+    if (substantive && summary && (!repeatedMessage || changed)) {
+      goal.continuationFailures = 0;
+      goal.pendingContinuationStart = null;
+      goal.pendingContinuationStarted = false;
+    }
     const continuationTurnCompleted = input.evaluateContinuation === true && goal.awaitingContinuationProgress && Boolean(messageID) && messageID !== goal.continuationBaselineMessageID;
     if (continuationTurnCompleted) {
       goal.awaitingContinuationProgress = false;
+      goal.pendingContinuationStart = null;
+      goal.pendingContinuationStarted = false;
       const lowOutput = outputTokens > 0 && outputTokens < (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD);
       const changedSinceContinuation = Boolean(summary && summary !== goal.continuationBaselineSummary);
       if (lowOutput && !changedSinceContinuation) {
@@ -523,7 +548,7 @@ async function reserveContinuation(sessionID, maxAutoTurns, minIntervalSeconds) 
     return snapshot(goal);
   });
 }
-async function recordContinuationResult(sessionID, result, maxFailures) {
+async function recordContinuationResult(sessionID, result, maxFailures, options) {
   return mutate((state) => {
     const goal = state.goals[sessionID];
     if (!goal || isClosed(goal.status))
@@ -531,15 +556,21 @@ async function recordContinuationResult(sessionID, result, maxFailures) {
     const now = nowSeconds();
     goal.updatedAt = now;
     if (result === "success") {
-      goal.continuationFailures = 0;
       if (goal.status === "active") {
+        goal.pendingContinuationStart = Date.now();
+        goal.pendingContinuationStarted = options?.started === true;
         goal.lastStatus = "Auto-continue prompt sent.";
-        goal.awaitingContinuationProgress = true;
+        if (options?.armNoProgress !== false)
+          goal.awaitingContinuationProgress = true;
       }
       return snapshot(goal);
     }
+    if (options?.requirePending && goal.pendingContinuationStart == null)
+      return null;
     goal.continuationFailures += 1;
     goal.awaitingContinuationProgress = false;
+    goal.pendingContinuationStart = null;
+    goal.pendingContinuationStarted = false;
     goal.lastStatus = `Auto-continue failed ${goal.continuationFailures} time(s).`;
     pushHistory(goal, "error", goal.lastStatus);
     if (goal.continuationFailures >= maxFailures) {
@@ -551,6 +582,37 @@ async function recordContinuationResult(sessionID, result, maxFailures) {
       goal.blocker = "Auto-continue prompt failed repeatedly. Resume the goal to retry.";
       pushHistory(goal, "paused", goal.lastStatus);
     }
+    return snapshot(goal);
+  });
+}
+async function markPendingContinuationStarted(sessionID) {
+  return mutate((state) => {
+    const goal = state.goals[sessionID];
+    if (!goal || goal.status !== "active")
+      return goal ? snapshot(goal) : null;
+    if (goal.pendingContinuationStart == null || goal.pendingContinuationStarted)
+      return snapshot(goal);
+    goal.pendingContinuationStarted = true;
+    goal.updatedAt = nowSeconds();
+    return snapshot(goal);
+  });
+}
+async function recordToolProgress(sessionID, text) {
+  return mutate((state) => {
+    const goal = state.goals[sessionID];
+    if (!goal || goal.status !== "active")
+      return goal ? snapshot(goal) : null;
+    const value = text?.trim() ?? "";
+    if (!value)
+      return snapshot(goal);
+    if (goal.continuationFailures === 0 && goal.pendingContinuationStart == null)
+      return snapshot(goal);
+    goal.continuationFailures = 0;
+    goal.pendingContinuationStart = null;
+    goal.pendingContinuationStarted = false;
+    goal.awaitingContinuationProgress = false;
+    goal.noProgressTurns = 0;
+    goal.updatedAt = nowSeconds();
     return snapshot(goal);
   });
 }
@@ -783,6 +845,11 @@ var DEFAULT_RESTRICTED_AGENTS = ["plan"];
 var TASK_SETTLE_DELAY_MS = 25;
 var SNAPSHOT_IDLE_HOLD_MS = 250;
 var MAX_TIMER_DELAY_MS = 2147483647;
+var STALE_PENDING_MS = 30000;
+var RETRY_SETTLE_MS = 25;
+var TRANSPORT_ERROR_PATTERN = /\b(?:network|fetch|socket|connect|connection|timeout|timed out|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|EPIPE|transport|stream|websocket|offline|internet|request failed|proxy)\b/i;
+var NON_TRANSPORT_TERMINAL_PATTERN = /\b(?:abort(?:ed)?|interrupt(?:ed|ion)?)\b/i;
+var NON_PROGRESS_TOOLS = new Set(["get_goal", "get_goal_history"]);
 var TASK_TERMINAL_STATES = new Set(["completed", "error", "cancelled"]);
 var PLAN_MODE_CREATE_NOTICE = 'Goal recorded while the session is in Plan mode, so execution is paused. Do not start implementation work now. Ask the user to switch to Build mode and resume the goal (for example with "/goal resume") to begin execution.';
 var LIMITED_GOAL_NOTICE = "Safety limit reached. Do not start or continue substantive work for this goal. Summarize useful progress, remaining work, and blockers, then wait for the user to resume or edit the goal.";
@@ -824,6 +891,9 @@ function commandNameFromOptions(options) {
 }
 function positiveIntegerOrNull2(value) {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : null;
+}
+function nonNegativeIntegerOrNull(value) {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 function timeoutMillisecondsFromSeconds(value) {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0)
@@ -993,6 +1063,84 @@ function isIdleEvent(event) {
     return true;
   const status = event.properties?.status;
   return event.type === "session.status" && typeof status === "object" && status !== null && status.type === "idle";
+}
+function isTransportError(error) {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  if (!message || NON_TRANSPORT_TERMINAL_PATTERN.test(message))
+    return false;
+  if (TRANSPORT_ERROR_PATTERN.test(message))
+    return true;
+  return false;
+}
+function transportErrorMessageFromEvent(props) {
+  for (const candidate of [props.error, props.message, props.reason]) {
+    if (typeof candidate === "string" && candidate.trim())
+      return candidate.trim();
+    if (isRecord(candidate)) {
+      for (const key of ["message", "error", "reason", "description"]) {
+        const value = candidate[key];
+        if (typeof value === "string" && value.trim())
+          return value.trim();
+      }
+    }
+  }
+  return "";
+}
+function continuationRetryDelayMs(minIntervalSeconds, attemptAt, now = Date.now()) {
+  return Math.max(0, attemptAt + minIntervalSeconds * 1000 - now) + RETRY_SETTLE_MS;
+}
+function continuationDelayFromSnapshot(minIntervalSeconds, lastContinuationAt, now = Date.now()) {
+  if (lastContinuationAt == null)
+    return RETRY_SETTLE_MS;
+  return Math.max(0, (lastContinuationAt + minIntervalSeconds + 1) * 1000 - now) + RETRY_SETTLE_MS;
+}
+var TOOL_FAILURE_STATES = new Set([
+  "failed",
+  "failure",
+  "error",
+  "cancelled",
+  "canceled",
+  "aborted",
+  "abort",
+  "interrupted",
+  "running",
+  "pending",
+  "in_progress",
+  "in-progress",
+  "incomplete",
+  "partial",
+  "timeout",
+  "timed_out"
+]);
+function toolOutputFailed(output) {
+  if (!isRecord(output))
+    return true;
+  if (typeof output.error === "string" && output.error.trim())
+    return true;
+  if (output.success === false)
+    return true;
+  const text = typeof output.output === "string" ? output.output.trim() : "";
+  const state = output.state ?? output.status;
+  if (typeof state === "string") {
+    const normalized = state.trim().toLowerCase();
+    if (TOOL_FAILURE_STATES.has(normalized))
+      return true;
+    if (["completed", "complete", "success", "succeeded", "ok", "done"].includes(normalized))
+      return false;
+  }
+  if (isRecord(output.metadata)) {
+    const metaState = output.metadata.state ?? output.metadata.status;
+    if (typeof metaState === "string" && TOOL_FAILURE_STATES.has(metaState.trim().toLowerCase()))
+      return true;
+  }
+  const taskState = parseTaskState(text);
+  if (taskState)
+    return taskState !== "completed";
+  if (/^state:\s*(failed|failure|error|cancelled|canceled|aborted|abort|interrupted|running|pending|incomplete|partial|timeout|timed_out)\b/im.test(text))
+    return true;
+  if (/^<error>/i.test(text) || /^<tool-error>/i.test(text) || /^error:/i.test(text))
+    return true;
+  return false;
 }
 function sessionIDFromEvent(event) {
   const direct = event.properties?.sessionID;
@@ -1277,15 +1425,20 @@ class TaskTracker {
 }
 async function recordAssistantMessage(sessionID, message, options, evaluateContinuation = false) {
   if (!message)
-    return;
-  await recordAssistantProgress(sessionID, {
-    messageID: messageID(message),
-    text: textFromMessage(message),
+    return { goal: null, progressed: false };
+  const before = await getGoal(sessionID);
+  const id = messageID(message) ?? "";
+  const text = textFromMessage(message);
+  const progressed = Boolean(/[\p{L}\p{N}]/u.test(text) && (id !== (before?.lastAssistantMessageID ?? "") || text !== (before?.lastAssistantText ?? "")));
+  const goal = await recordAssistantProgress(sessionID, {
+    messageID: id,
+    text,
     outputTokens: outputTokensFromMessage(message) ?? null,
     noProgressTokenThreshold: positiveIntegerOrNull2(options.no_progress_token_threshold),
     maxNoProgressTurns: positiveIntegerOrNull2(options.max_no_progress_turns),
     evaluateContinuation
   });
+  return { goal, progressed };
 }
 function mergeSystemReminder(output, reminder) {
   if (!reminder.trim())
@@ -1311,7 +1464,7 @@ var server = async ({ client }, options) => {
   const autoContinue = options?.auto_continue ?? true;
   const deferWhileTasksActive = options?.defer_while_tasks_active ?? true;
   const maxAutoTurns = positiveIntegerOrNull2(options?.max_auto_turns) ?? DEFAULT_MAX_AUTO_TURNS;
-  const minInterval = positiveIntegerOrNull2(options?.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS;
+  const minInterval = nonNegativeIntegerOrNull(options?.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS;
   const maxTurnTimeMs = timeoutMillisecondsFromSeconds(options?.max_turn_time);
   const maxPromptFailures = positiveIntegerOrNull2(options?.max_prompt_failures) ?? DEFAULT_MAX_PROMPT_FAILURES;
   const registerCommand = options?.register_command ?? true;
@@ -1321,6 +1474,9 @@ var server = async ({ client }, options) => {
   const scheduledContinuations = new Map;
   const turnWatchdogs = new Map;
   const busySessions = new Set;
+  const nativeRetrySessions = new Set;
+  const locallyDeliveredPendingSessions = new Set;
+  const watchdogRescuedSessions = new Set;
   const planAgents = restrictedAgentSet(options);
   const isPlanAgent = (agent) => typeof agent === "string" && planAgents.has(agent.trim().toLowerCase());
   async function createGoalFromTool(input, context) {
@@ -1355,6 +1511,8 @@ var server = async ({ client }, options) => {
   function armTurnWatchdog(sessionID) {
     if (maxTurnTimeMs == null)
       return;
+    if (watchdogRescuedSessions.has(sessionID))
+      return;
     clearTurnWatchdog(sessionID);
     const watchdog = {
       timer: setTimeout(() => void runTurnWatchdog(sessionID, watchdog), maxTurnTimeMs)
@@ -1367,7 +1525,7 @@ var server = async ({ client }, options) => {
   async function runTurnWatchdog(sessionID, watchdog) {
     let claimedContinuation = false;
     try {
-      if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID))
+      if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID) || watchdogRescuedSessions.has(sessionID))
         return;
       const goal = await getGoal(sessionID);
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID))
@@ -1380,6 +1538,7 @@ var server = async ({ client }, options) => {
       const latestTurnAgent = agentFromMessage(latestAssistant);
       if (isPlanAgent(latestTurnAgent))
         return;
+      await recordAssistantMessage(sessionID, latestAssistant, options ?? {});
       const taskStatus = await taskBlockStatus(sessionID);
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID))
         return;
@@ -1393,9 +1552,16 @@ var server = async ({ client }, options) => {
       turnWatchdogs.delete(sessionID);
       activeContinuations.add(sessionID);
       claimedContinuation = true;
+      watchdogRescuedSessions.add(sessionID);
       await sendContinuation(client, sessionID, continuationPrompt(current), current.lastPromptAgent ?? latestTurnAgent ?? null);
+      await recordContinuationResult(sessionID, "success", maxPromptFailures, { armNoProgress: false, started: true });
+      locallyDeliveredPendingSessions.add(sessionID);
+      clearTurnWatchdog(sessionID);
     } catch (error) {
       try {
+        if (claimedContinuation && isTransportError(error)) {
+          await recordContinuationResult(sessionID, "failure", maxPromptFailures);
+        }
         await client.app?.log?.({
           body: {
             service: "opencode-goal-plugin",
@@ -1414,19 +1580,44 @@ var server = async ({ client }, options) => {
         turnWatchdogs.delete(sessionID);
     }
   }
-  function scheduleSettledContinuation(sessionID, delayMs = TASK_SETTLE_DELAY_MS) {
-    if (scheduledContinuations.has(sessionID))
+  function cancelScheduledContinuation(sessionID) {
+    const scheduled = scheduledContinuations.get(sessionID);
+    if (scheduled)
+      clearTimeout(scheduled.timer);
+    scheduledContinuations.delete(sessionID);
+  }
+  function scheduleSettledContinuation(sessionID, delayMs = TASK_SETTLE_DELAY_MS, replace = false, purpose = "settle") {
+    if (!replace && scheduledContinuations.has(sessionID))
       return;
-    const timer = setTimeout(() => {
-      scheduledContinuations.delete(sessionID);
-      runAutoContinue(sessionID, true);
+    if (replace)
+      cancelScheduledContinuation(sessionID);
+    const scheduled = {};
+    const timer = setTimeout(async () => {
+      try {
+        if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID))
+          return;
+        if (purpose === "retry") {
+          const goal = await getGoal(sessionID);
+          if (!goal || goal.continuationFailures === 0 && goal.pendingContinuationStart == null)
+            return;
+        }
+        if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID))
+          return;
+        await runAutoContinue(sessionID, true, scheduled);
+      } finally {
+        if (scheduledContinuations.get(sessionID) === scheduled)
+          scheduledContinuations.delete(sessionID);
+      }
     }, Math.max(0, delayMs));
+    scheduled.timer = timer;
+    scheduled.purpose = purpose;
     const maybeUnref = timer;
     if (typeof maybeUnref.unref === "function")
       maybeUnref.unref();
-    scheduledContinuations.set(sessionID, timer);
+    scheduledContinuations.set(sessionID, scheduled);
   }
-  async function runAutoContinue(sessionID, fromTaskDeferral = false) {
+  async function runAutoContinue(sessionID, fromTaskDeferral = false, scheduled) {
+    let reservedAt = null;
     if (busySessions.has(sessionID))
       return;
     if (activeContinuations.has(sessionID))
@@ -1438,13 +1629,19 @@ var server = async ({ client }, options) => {
       const taskStatus = await taskBlockStatus(sessionID);
       if (taskStatus && taskStatus.blocked) {
         taskDeferredSessions.add(sessionID);
-        if (taskStatus.retryAt != null)
-          scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now());
+        if (taskStatus.retryAt != null) {
+          scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now(), scheduled != null);
+        }
         return;
       }
       if (busySessions.has(sessionID))
         return;
-      await recordAssistantMessage(sessionID, latestAssistant, options ?? {}, true);
+      const observed = await recordAssistantMessage(sessionID, latestAssistant, options ?? {}, true);
+      const queued = scheduledContinuations.get(sessionID);
+      if (observed.progressed && queued?.purpose !== "settle")
+        cancelScheduledContinuation(sessionID);
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled)
+        return;
       const current = await getGoal(sessionID);
       if (!current)
         return;
@@ -1461,13 +1658,45 @@ var server = async ({ client }, options) => {
         return;
       }
       taskDeferredSessions.delete(sessionID);
+      if (current.status === "active" && current.pendingContinuationStart != null) {
+        const pendingAgeMs = Date.now() - current.pendingContinuationStart;
+        const deliveredLocally = locallyDeliveredPendingSessions.has(sessionID);
+        if (!current.pendingContinuationStarted && (deliveredLocally || pendingAgeMs < STALE_PENDING_MS)) {
+          return;
+        }
+        const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
+          requirePending: true
+        });
+        if (afterFailure)
+          locallyDeliveredPendingSessions.delete(sessionID);
+        if (autoContinue && afterFailure?.status === "active") {
+          scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, current.pendingContinuationStart), true, "retry");
+        }
+        return;
+      }
+      const queuedBeforeReserve = scheduledContinuations.get(sessionID);
+      if (queuedBeforeReserve && queuedBeforeReserve !== scheduled)
+        return;
+      if (!autoContinue)
+        return;
+      if (nativeRetrySessions.has(sessionID))
+        return;
       const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval);
       if (!goal)
         return;
+      if (nativeRetrySessions.has(sessionID))
+        return;
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled)
+        return;
+      reservedAt = Date.now();
       await sendContinuation(client, sessionID, goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal), goal.lastPromptAgent ?? latestTurnAgent ?? null);
       await recordContinuationResult(sessionID, "success", maxPromptFailures);
+      locallyDeliveredPendingSessions.add(sessionID);
     } catch (error) {
-      await recordContinuationResult(sessionID, "failure", maxPromptFailures);
+      const afterFailure = reservedAt == null ? null : await recordContinuationResult(sessionID, "failure", maxPromptFailures);
+      if (isTransportError(error) && autoContinue && reservedAt != null && afterFailure?.status === "active") {
+        scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, reservedAt), true, "retry");
+      }
       await client.app?.log?.({
         body: {
           service: "opencode-goal-plugin",
@@ -1482,12 +1711,15 @@ var server = async ({ client }, options) => {
   }
   return {
     async dispose() {
-      for (const timer of scheduledContinuations.values())
-        clearTimeout(timer);
+      for (const scheduled of scheduledContinuations.values())
+        clearTimeout(scheduled.timer);
       scheduledContinuations.clear();
       for (const watchdog of turnWatchdogs.values())
         clearTimeout(watchdog.timer);
       turnWatchdogs.clear();
+      watchdogRescuedSessions.clear();
+      locallyDeliveredPendingSessions.clear();
+      nativeRetrySessions.clear();
     },
     async config(config) {
       if (!registerCommand)
@@ -1598,6 +1830,27 @@ var server = async ({ client }, options) => {
     },
     async "tool.execute.after"(input, output) {
       taskTracker.noteTaskOutput(input, output);
+      const sessionID = typeof input?.sessionID === "string" ? input.sessionID : undefined;
+      if (!sessionID)
+        return;
+      if (typeof input?.tool === "string" && NON_PROGRESS_TOOLS.has(input.tool.toLowerCase()))
+        return;
+      const toolResult = output;
+      if (toolOutputFailed(toolResult))
+        return;
+      const text = typeof toolResult.output === "string" ? toolResult.output : undefined;
+      if (!text)
+        return;
+      const before = await getGoal(sessionID);
+      const scheduled = scheduledContinuations.get(sessionID);
+      const hasFailureEpisode = Boolean(before && (before.continuationFailures > 0 || before.pendingContinuationStart != null));
+      if (!before || !hasFailureEpisode && scheduled?.purpose !== "recovery")
+        return;
+      const progressed = await recordToolProgress(sessionID, text);
+      if (progressed?.continuationFailures === 0 && progressed.pendingContinuationStart == null) {
+        locallyDeliveredPendingSessions.delete(sessionID);
+        cancelScheduledContinuation(sessionID);
+      }
     },
     async "chat.message"(input, output) {
       const sessionID = typeof input?.sessionID === "string" ? input.sessionID : output.message?.sessionID;
@@ -1612,7 +1865,10 @@ var server = async ({ client }, options) => {
       if (!sessionID)
         return;
       await accountUsage(sessionID, tokensFromMessages(output.messages));
-      await recordAssistantMessage(sessionID, latestAssistantMessage(output.messages), options ?? {});
+      const observed = await recordAssistantMessage(sessionID, latestAssistantMessage(output.messages), options ?? {});
+      const scheduled = scheduledContinuations.get(sessionID);
+      if (observed.progressed && scheduled?.purpose !== "settle")
+        cancelScheduledContinuation(sessionID);
     },
     async "experimental.chat.system.transform"(input, output) {
       if (typeof input.sessionID !== "string")
@@ -1639,31 +1895,67 @@ var server = async ({ client }, options) => {
       if (sessionID && eventType === "session.status") {
         const status = event.properties?.status;
         if (isRecord(status) && typeof status.type === "string") {
-          if (status.type === "busy")
+          if (status.type === "busy") {
             busySessions.add(sessionID);
+            nativeRetrySessions.delete(sessionID);
+          }
           if (status.type === "busy")
             armTurnWatchdog(sessionID);
+          if (status.type === "busy")
+            await markPendingContinuationStarted(sessionID);
           if (status.type === "idle") {
             busySessions.delete(sessionID);
+            nativeRetrySessions.delete(sessionID);
             clearTurnWatchdog(sessionID);
+            watchdogRescuedSessions.delete(sessionID);
           }
-          if (status.type === "retry")
+          if (status.type === "retry") {
+            nativeRetrySessions.add(sessionID);
             clearTurnWatchdog(sessionID);
+            cancelScheduledContinuation(sessionID);
+          }
           taskTracker.observeSessionStatus(sessionID, status.type);
         }
       }
       if (sessionID && eventType === "session.idle") {
         busySessions.delete(sessionID);
+        nativeRetrySessions.delete(sessionID);
         clearTurnWatchdog(sessionID);
+        watchdogRescuedSessions.delete(sessionID);
         taskTracker.observeSessionStatus(sessionID, "idle");
+      }
+      if (sessionID && eventType === "session.error") {
+        busySessions.delete(sessionID);
+        nativeRetrySessions.delete(sessionID);
+        clearTurnWatchdog(sessionID);
+        watchdogRescuedSessions.delete(sessionID);
+        const props = event.properties ?? {};
+        const errorMessage = transportErrorMessageFromEvent(props);
+        if (errorMessage && isTransportError(errorMessage)) {
+          const goal = await getGoal(sessionID);
+          if (goal?.status === "active") {
+            if (goal.pendingContinuationStart != null) {
+              const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
+                requirePending: true
+              });
+              if (afterFailure)
+                locallyDeliveredPendingSessions.delete(sessionID);
+              if (autoContinue && afterFailure?.status === "active") {
+                scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, goal.pendingContinuationStart), true, "retry");
+              }
+            } else if (autoContinue) {
+              scheduleSettledContinuation(sessionID, continuationDelayFromSnapshot(minInterval, goal.lastContinuationAt), false, "recovery");
+            }
+          }
+        }
       }
       if (sessionID && eventType === "session.deleted") {
         busySessions.delete(sessionID);
         clearTurnWatchdog(sessionID);
-        const scheduled = scheduledContinuations.get(sessionID);
-        if (scheduled)
-          clearTimeout(scheduled);
-        scheduledContinuations.delete(sessionID);
+        watchdogRescuedSessions.delete(sessionID);
+        locallyDeliveredPendingSessions.delete(sessionID);
+        nativeRetrySessions.delete(sessionID);
+        cancelScheduledContinuation(sessionID);
         taskDeferredSessions.delete(sessionID);
         taskTracker.observeSessionDeleted(sessionID);
       }
@@ -1671,11 +1963,16 @@ var server = async ({ client }, options) => {
         const props = event.properties ?? {};
         const message = [props.info, props.message].find((value) => value && typeof value === "object");
         taskTracker.observeAssistantMessage(sessionID, message);
-        await recordAssistantMessage(sessionID, message, options ?? {});
+        const observed = await recordAssistantMessage(sessionID, message, options ?? {});
+        const scheduled = scheduledContinuations.get(sessionID);
+        if (observed.progressed && scheduled?.purpose !== "settle")
+          cancelScheduledContinuation(sessionID);
       }
-      if (!autoContinue || !isIdleEvent(event))
+      if (!isIdleEvent(event))
         return;
       if (!sessionID)
+        return;
+      if (!autoContinue && (await getGoal(sessionID))?.pendingContinuationStart == null)
         return;
       await runAutoContinue(sessionID);
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import type * as PluginV2 from "@opencode-ai/plugin-v2"
 import type { Info as ToolV2Info } from "@opencode-ai/plugin-v2/promise/tool"
 import type { Tool as ToolSchema } from "@opencode-ai/schema/tool"
 import { z } from "zod"
-import type { GoalSnapshot } from "./state"
+import type { GoalSnapshot, InternalGoalSnapshot, PendingAttempt } from "./state"
 import {
   accountUsage,
   clearGoal,
@@ -12,6 +12,7 @@ import {
   estimateTokensFromText,
   formatGoalHistory,
   getGoal,
+  getGoalInternal,
   markGoalUnmet,
   pauseGoalForPlanMode,
   recordAssistantProgress,
@@ -20,6 +21,7 @@ import {
   recordToolProgress,
   markPendingContinuationStarted,
   reserveContinuation,
+  rollbackContinuationAttempt,
   setGoalStatus,
   updateGoalObjective,
 } from "./state"
@@ -358,6 +360,36 @@ function continuationDelayFromSnapshot(minIntervalSeconds: number, lastContinuat
   return Math.max(0, (lastContinuationAt + minIntervalSeconds + 1) * 1000 - now) + RETRY_SETTLE_MS
 }
 
+function pendingAttemptOf(goal: InternalGoalSnapshot | null): PendingAttempt | null {
+  return goal?.pendingAttempt ?? null
+}
+
+// A reserved-and-delivered attempt warrants an unresolved no-response failure
+// when the provider actually picked it up (a busy fired) or when the attempt
+// went stale after a plugin restart. A locally delivered-but-unstarted attempt
+// is left alone: a paired duplicate idle before any busy must never count a
+// failure or send a duplicate.
+function pendingReadyForFailure(attempt: PendingAttempt | null, deliveredLocally: boolean, now = Date.now()) {
+  if (!attempt) return false
+  if (attempt.started) return true
+  if (deliveredLocally) return false
+  return now - attempt.reservedAt >= STALE_PENDING_MS
+}
+
+// Substantive assistant progress that resolved the current pending attempt must
+// clear the locally-delivered marker. A stale marker would mask a later
+// locally-delivered-but-unstarted attempt from its stale-recovery path,
+// wedging the next continuation.
+async function reconcileLocalMarkerAfterProgress(
+  locallyDelivered: Set<string>,
+  sessionID: string,
+  goal: GoalSnapshot | null,
+) {
+  if (!goal || goal.continuationFailures !== 0) return
+  const internal = await getGoalInternal(sessionID)
+  if (internal && internal.pendingAttempt == null) locallyDelivered.delete(sessionID)
+}
+
 const TOOL_FAILURE_STATES = new Set([
   "failed",
   "failure",
@@ -686,7 +718,7 @@ class TaskTracker {
 
 async function recordAssistantMessage(
   sessionID: string,
-  message: { info?: unknown; role?: unknown; id?: unknown; parts?: unknown[] } | undefined,
+  message: { info?: unknown; role?: unknown; id?: unknown; parts?: unknown[]; time?: unknown } | undefined,
   options: Options,
   evaluateContinuation = false,
 ) {
@@ -704,6 +736,7 @@ async function recordAssistantMessage(
     noProgressTokenThreshold: positiveIntegerOrNull(options.no_progress_token_threshold),
     maxNoProgressTurns: positiveIntegerOrNull(options.max_no_progress_turns),
     evaluateContinuation,
+    completedAt: messageCompletedAt(message),
   })
   return { goal, progressed }
 }
@@ -810,6 +843,7 @@ type V2StepRecord = {
   agent?: string
   text: string
   outputTokens: number | null
+  completedAt: number | null
 }
 
 function textFromToolResult(result: { output?: unknown; content?: unknown }): string | undefined {
@@ -820,6 +854,19 @@ function textFromToolResult(result: { output?: unknown; content?: unknown }): st
     return text || undefined
   }
   return undefined
+}
+
+// Tool calls are correlated to the pending attempt that was active when they
+// started so a delayed output cannot clear a newer attempt. Keys are scoped by
+// session and call id to avoid collisions between concurrent calls.
+function toolAttemptKey(sessionID: string, callID: string) {
+  return `${sessionID}\0${callID}`
+}
+
+function clearToolAttemptsForSession(attempts: Map<string, string | null>, sessionID: string) {
+  for (const key of [...attempts.keys()]) {
+    if (key.startsWith(`${sessionID}\0`)) attempts.delete(key)
+  }
 }
 
 const server: Plugin = async ({ client }, options?: Options) => {
@@ -838,6 +885,11 @@ const server: Plugin = async ({ client }, options?: Options) => {
   const busySessions = new Set<string>()
   const nativeRetrySessions = new Set<string>()
   const locallyDeliveredPendingSessions = new Set<string>()
+  // Pending-attempt id captured at tool-call start, keyed by session+call id,
+  // so a delayed tool output is only treated as progress for the attempt it
+  // actually ran under. Entries are removed on execute.after, session deletion,
+  // and dispose.
+  const toolAttempts = new Map<string, string | null>()
   // Sessions whose busy episode already received a watchdog rescue. Cleared
   // when the episode ends (idle/deleted), so each busy episode rescues at most
   // once and a rescue prompt cannot recursively re-arm the watchdog.
@@ -845,6 +897,9 @@ const server: Plugin = async ({ client }, options?: Options) => {
   const planAgents = restrictedAgentSet(options)
   const isPlanAgent = (agent: unknown) => typeof agent === "string" && planAgents.has(agent.trim().toLowerCase())
   const goalServices: GoalServices = { options: options ?? {}, isPlanAgent }
+  // Set by dispose so in-flight operations triggered before disposal cannot
+  // schedule new timers or invoke continuations afterward.
+  let disposed = false
 
   async function taskBlockStatus(sessionID: string) {
     if (!deferWhileTasksActive) return false
@@ -877,6 +932,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
   async function runTurnWatchdog(sessionID: string, watchdog: TurnWatchdog) {
     let claimedContinuation = false
     try {
+      if (disposed) return
       if (
         turnWatchdogs.get(sessionID) !== watchdog ||
         !busySessions.has(sessionID) ||
@@ -892,7 +948,8 @@ const server: Plugin = async ({ client }, options?: Options) => {
       if (isPlanAgent(latestTurnAgent)) return
       // Establish the pre-rescue baseline so this same historical message
       // cannot later be mistaken for progress from the rescue prompt.
-      await recordAssistantMessage(sessionID, latestAssistant, options ?? {})
+      const observedBeforeRescue = await recordAssistantMessage(sessionID, latestAssistant, options ?? {})
+      await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, observedBeforeRescue.goal)
       const taskStatus = await taskBlockStatus(sessionID)
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID)) return
       if (taskStatus && taskStatus.blocked) return
@@ -950,6 +1007,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
     replace = false,
     purpose: ScheduledContinuation["purpose"] = "settle",
   ) {
+    if (disposed) return
     if (!replace && scheduledContinuations.has(sessionID)) return
     if (replace) cancelScheduledContinuation(sessionID)
     const scheduled = {} as ScheduledContinuation
@@ -957,8 +1015,8 @@ const server: Plugin = async ({ client }, options?: Options) => {
       try {
         if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID)) return
         if (purpose === "retry") {
-          const goal = await getGoal(sessionID)
-          if (!goal || (goal.continuationFailures === 0 && goal.pendingContinuationStart == null)) return
+          const goal = await getGoalInternal(sessionID)
+          if (!goal || (goal.continuationFailures === 0 && goal.pendingAttempt == null)) return
         }
         if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID)) return
         await runAutoContinue(sessionID, true, scheduled)
@@ -978,10 +1036,13 @@ const server: Plugin = async ({ client }, options?: Options) => {
     fromTaskDeferral = false,
     scheduled?: ScheduledContinuation,
   ) {
-    let reservedAt: number | null = null
+    if (disposed) return
     if (busySessions.has(sessionID)) return
     if (activeContinuations.has(sessionID)) return
     activeContinuations.add(sessionID)
+    // Anchor for bounded-retry scheduling, declared at function scope so the
+    // catch block can use it. Initialized to "now" as a safe default.
+    let attemptReservedAt = Date.now()
     try {
       const latestAssistant = await fetchLatestAssistant(client, sessionID)
       taskTracker.observeAssistantMessage(sessionID, latestAssistant)
@@ -995,10 +1056,11 @@ const server: Plugin = async ({ client }, options?: Options) => {
       }
       if (busySessions.has(sessionID)) return
       const observed = await recordAssistantMessage(sessionID, latestAssistant, options ?? {}, true)
+      await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, observed.goal)
       const queued = scheduledContinuations.get(sessionID)
       if (observed.progressed && queued?.purpose !== "settle") cancelScheduledContinuation(sessionID)
       if (scheduled && scheduledContinuations.get(sessionID) !== scheduled) return
-      const current = await getGoal(sessionID)
+      const current = await getGoalInternal(sessionID)
       if (!current) return
       const latestTurnAgent = agentFromMessage(latestAssistant)
       if (isPlanAgent(current.lastPromptAgent) || isPlanAgent(latestTurnAgent)) {
@@ -1019,10 +1081,10 @@ const server: Plugin = async ({ client }, options?: Options) => {
       // go stale (restart recovery). Once started, the following logical idle
       // with no substantive progress counts exactly one unresolved failure and
       // schedules a bounded retry at the remaining min interval.
-      if (current.status === "active" && current.pendingContinuationStart != null) {
-        const pendingAgeMs = Date.now() - current.pendingContinuationStart
+      const attempt = pendingAttemptOf(current)
+      if (current.status === "active" && attempt != null) {
         const deliveredLocally = locallyDeliveredPendingSessions.has(sessionID)
-        if (!current.pendingContinuationStarted && (deliveredLocally || pendingAgeMs < STALE_PENDING_MS)) {
+        if (!pendingReadyForFailure(attempt, deliveredLocally)) {
           return
         }
         const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
@@ -1032,7 +1094,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
         if (autoContinue && afterFailure?.status === "active") {
           scheduleSettledContinuation(
             sessionID,
-            continuationRetryDelayMs(minInterval, current.pendingContinuationStart),
+            continuationRetryDelayMs(minInterval, attempt.reservedAt),
             true,
             "retry",
           )
@@ -1048,23 +1110,68 @@ const server: Plugin = async ({ client }, options?: Options) => {
       if (!autoContinue) return
       if (nativeRetrySessions.has(sessionID)) return
 
+      // Reserve (and persist) the attempt BEFORE delivery so a racing busy can
+      // correlate to it. The attempt stays reserved until delivery or rollback.
       const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval)
       if (!goal) return
-      if (nativeRetrySessions.has(sessionID)) return
-      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled) return
-      reservedAt = Date.now()
+      attemptReservedAt = goal.pendingAttempt?.reservedAt ?? Date.now()
+      if (nativeRetrySessions.has(sessionID)) {
+        await rollbackContinuationAttempt(sessionID)
+        return
+      }
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled) {
+        await rollbackContinuationAttempt(sessionID)
+        return
+      }
       await sendContinuation(
         client,
         sessionID,
         goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal),
         goal.lastPromptAgent ?? latestTurnAgent ?? null,
       )
-      await recordContinuationResult(sessionID, "success", maxPromptFailures)
+      if (disposed) {
+        // The plugin was torn down while the prompt was in flight: roll the
+        // reserved turn back instead of committing a continuation afterward.
+        await rollbackContinuationAttempt(sessionID)
+        return
+      }
+      // Commit the delivered attempt. A busy that raced the resolution already
+      // marked it started (started=true is preserved).
+      const delivered = await recordContinuationResult(sessionID, "success", maxPromptFailures)
       locallyDeliveredPendingSessions.add(sessionID)
+      if (!delivered?.pendingAttempt?.delivered) {
+        // The attempt was not present at delivery time (e.g. disposed mid-send):
+        // do not leave a phantom reserved turn.
+        await rollbackContinuationAttempt(sessionID)
+      }
     } catch (error) {
-      const afterFailure = reservedAt == null ? null : await recordContinuationResult(sessionID, "failure", maxPromptFailures)
-      if (isTransportError(error) && autoContinue && reservedAt != null && afterFailure?.status === "active") {
-        scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, reservedAt), true, "retry")
+      if (disposed) {
+        // The plugin was torn down while the prompt was in flight and the
+        // prompt then failed: the reserved attempt was never delivered, so
+        // roll it back instead of counting a transport failure or consuming an
+        // auto-turn.
+        await rollbackContinuationAttempt(sessionID)
+        return
+      }
+      if (isTransportError(error)) {
+        // A transport failure is a real attempt: count it toward the
+        // max_prompt_failures ceiling and schedule a bounded retry at the
+        // remaining minimum interval. Keep the reserved autoTurn consumed.
+        const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures)
+        if (autoContinue && afterFailure?.status === "active") {
+          scheduleSettledContinuation(
+            sessionID,
+            continuationRetryDelayMs(minInterval, attemptReservedAt),
+            true,
+            "retry",
+          )
+        }
+      } else {
+        // Non-transport prompt errors (provider/config faults, aborts) are not
+        // transport or no-response failures: they do not increment the ceiling
+        // or auto-retry. Roll back the unconsumed reserved turn so it does not
+        // waste an auto-continue budget, and preserve useful error logging.
+        await rollbackContinuationAttempt(sessionID)
       }
       await client.app?.log?.({
         body: {
@@ -1081,6 +1188,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
 
   return {
     async dispose() {
+      disposed = true
       for (const scheduled of scheduledContinuations.values()) clearTimeout(scheduled.timer)
       scheduledContinuations.clear()
       for (const watchdog of turnWatchdogs.values()) clearTimeout(watchdog.timer)
@@ -1088,6 +1196,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
       watchdogRescuedSessions.clear()
       locallyDeliveredPendingSessions.clear()
       nativeRetrySessions.clear()
+      toolAttempts.clear()
     },
     async config(config) {
       if (!registerCommand) return
@@ -1188,6 +1297,12 @@ const server: Plugin = async ({ client }, options?: Options) => {
     },
     async "tool.execute.before"(input) {
       taskTracker.noteTaskCall(input as { tool?: unknown; sessionID?: unknown; callID?: unknown })
+      const sessionID = typeof input?.sessionID === "string" ? input.sessionID : undefined
+      const callID = typeof input?.callID === "string" ? input.callID : undefined
+      if (sessionID && callID) {
+        const goal = await getGoalInternal(sessionID)
+        toolAttempts.set(toolAttemptKey(sessionID, callID), goal?.pendingAttempt?.id ?? null)
+      }
     },
     async "tool.execute.after"(input, output) {
       taskTracker.noteTaskOutput(
@@ -1195,6 +1310,10 @@ const server: Plugin = async ({ client }, options?: Options) => {
         output as { output?: unknown },
       )
       const sessionID = typeof input?.sessionID === "string" ? input.sessionID : undefined
+      const callID = typeof input?.callID === "string" ? input.callID : undefined
+      const attemptKey = sessionID && callID ? toolAttemptKey(sessionID, callID) : undefined
+      const expectedAttemptID = attemptKey ? toolAttempts.get(attemptKey) : undefined
+      if (attemptKey) toolAttempts.delete(attemptKey)
       if (!sessionID) return
       if (typeof input?.tool === "string" && NON_PROGRESS_TOOLS.has(input.tool.toLowerCase())) return
       const toolResult = output as { output?: unknown; error?: unknown }
@@ -1204,14 +1323,14 @@ const server: Plugin = async ({ client }, options?: Options) => {
       if (toolOutputFailed(toolResult)) return
       const text = typeof toolResult.output === "string" ? toolResult.output : undefined
       if (!text) return
-      const before = await getGoal(sessionID)
+      const before = await getGoalInternal(sessionID)
       const scheduled = scheduledContinuations.get(sessionID)
       const hasFailureEpisode = Boolean(
-        before && (before.continuationFailures > 0 || before.pendingContinuationStart != null),
+        before && (before.continuationFailures > 0 || before.pendingAttempt != null),
       )
       if (!before || (!hasFailureEpisode && scheduled?.purpose !== "recovery")) return
-      const progressed = await recordToolProgress(sessionID, text)
-      if (progressed?.continuationFailures === 0 && progressed.pendingContinuationStart == null) {
+      const progressed = await recordToolProgress(sessionID, text, expectedAttemptID)
+      if (progressed?.continuationFailures === 0 && progressed.pendingAttempt == null) {
         locallyDeliveredPendingSessions.delete(sessionID)
         cancelScheduledContinuation(sessionID)
       }
@@ -1231,6 +1350,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
       if (!sessionID) return
       await accountUsage(sessionID, tokensFromMessages(output.messages))
       const observed = await recordAssistantMessage(sessionID, latestAssistantMessage(output.messages), options ?? {})
+      await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, observed.goal)
       const scheduled = scheduledContinuations.get(sessionID)
       if (observed.progressed && scheduled?.purpose !== "settle") cancelScheduledContinuation(sessionID)
     },
@@ -1284,16 +1404,23 @@ const server: Plugin = async ({ client }, options?: Options) => {
         taskTracker.observeSessionStatus(sessionID, "idle")
       }
       if (sessionID && eventType === "session.error") {
+        const inNativeRetry = nativeRetrySessions.has(sessionID)
         busySessions.delete(sessionID)
-        nativeRetrySessions.delete(sessionID)
         clearTurnWatchdog(sessionID)
+        // A native provider retry episode is already recovering, so a transport
+        // error inside it must not schedule plugin recovery. A retry status can
+        // arrive before the error, so check the marker before clearing it; the
+        // episode ends (and the marker is removed) on the next busy or idle.
+        if (inNativeRetry) return
+        nativeRetrySessions.delete(sessionID)
         watchdogRescuedSessions.delete(sessionID)
         const props = (event as { properties?: Record<string, unknown> }).properties ?? {}
         const errorMessage = transportErrorMessageFromEvent(props)
         if (errorMessage && isTransportError(errorMessage)) {
-          const goal = await getGoal(sessionID)
+          const goal = await getGoalInternal(sessionID)
           if (goal?.status === "active") {
-            if (goal.pendingContinuationStart != null) {
+            const attempt = pendingAttemptOf(goal)
+            if (attempt != null) {
               // The pending attempt failed at the transport level: count one
               // failure and retry at the remaining min interval.
               const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
@@ -1303,7 +1430,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
               if (autoContinue && afterFailure?.status === "active") {
                 scheduleSettledContinuation(
                   sessionID,
-                  continuationRetryDelayMs(minInterval, goal.pendingContinuationStart),
+                  continuationRetryDelayMs(minInterval, attempt.reservedAt),
                   true,
                   "retry",
                 )
@@ -1330,6 +1457,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
         nativeRetrySessions.delete(sessionID)
         cancelScheduledContinuation(sessionID)
         taskDeferredSessions.delete(sessionID)
+        clearToolAttemptsForSession(toolAttempts, sessionID)
         taskTracker.observeSessionDeleted(sessionID)
       }
       if (sessionID && (event as { type?: string }).type === "message.updated") {
@@ -1339,13 +1467,14 @@ const server: Plugin = async ({ client }, options?: Options) => {
           | undefined
         taskTracker.observeAssistantMessage(sessionID, message)
         const observed = await recordAssistantMessage(sessionID, message, options ?? {})
+        await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, observed.goal)
         const scheduled = scheduledContinuations.get(sessionID)
         if (observed.progressed && scheduled?.purpose !== "settle") cancelScheduledContinuation(sessionID)
       }
 
       if (!isIdleEvent(event as never)) return
       if (!sessionID) return
-      if (!autoContinue && (await getGoal(sessionID))?.pendingContinuationStart == null) return
+      if (!autoContinue && (await getGoalInternal(sessionID))?.pendingAttempt == null) return
       await runAutoContinue(sessionID)
     },
   }
@@ -1364,16 +1493,22 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
   const autoContinue = options.auto_continue ?? true
   const deferWhileTasksActive = options.defer_while_tasks_active ?? true
   const maxAutoTurns = positiveIntegerOrNull(options.max_auto_turns) ?? DEFAULT_MAX_AUTO_TURNS
-  const minInterval = positiveIntegerOrNull(options.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS
+  const minInterval = nonNegativeIntegerOrNull(options.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS
   const maxTurnTimeMs = timeoutMillisecondsFromSeconds(options.max_turn_time)
   const maxPromptFailures = positiveIntegerOrNull(options.max_prompt_failures) ?? DEFAULT_MAX_PROMPT_FAILURES
   const registerCommand = options.register_command ?? true
   const commandName = commandNameFromOptions(options)
   const taskTracker = new TaskTracker()
   const taskDeferredSessions = new Set<string>()
-  const scheduledContinuations = new Map<string, ReturnType<typeof setTimeout>>()
+  const scheduledContinuations = new Map<string, ScheduledContinuation>()
   const turnWatchdogs = new Map<string, TurnWatchdog>()
   const busySessions = new Set<string>()
+  const nativeRetrySessions = new Set<string>()
+  const locallyDeliveredPendingSessions = new Set<string>()
+  const watchdogRescuedSessions = new Set<string>()
+  // See the V1 comment: pending-attempt id captured at tool-call start so a
+  // delayed tool output cannot clear a newer pending attempt.
+  const toolAttempts = new Map<string, string | null>()
   const planAgents = restrictedAgentSet(options)
   const isPlanAgent = (agent: unknown) => typeof agent === "string" && planAgents.has(agent.trim().toLowerCase())
   const goalServices: GoalServices = { options, isPlanAgent }
@@ -1382,6 +1517,7 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
   const stepTextBuffers = new Map<string, string>()
   const stepTokenSums = new Map<string, number>()
   const registrations: Array<{ dispose(): Promise<void> }> = []
+  let disposed = false
 
   function stepKey(sessionID: string, messageID: string) {
     return `${sessionID}\0${messageID}`
@@ -1412,6 +1548,7 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
 
   function armTurnWatchdog(sessionID: string) {
     if (maxTurnTimeMs == null) return
+    if (watchdogRescuedSessions.has(sessionID)) return
     clearTurnWatchdog(sessionID)
     const watchdog: TurnWatchdog = {
       timer: setTimeout(() => void runTurnWatchdog(sessionID, watchdog), maxTurnTimeMs),
@@ -1424,7 +1561,9 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
   async function runTurnWatchdog(sessionID: string, watchdog: TurnWatchdog) {
     let claimedContinuation = false
     try {
-      if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID)) return
+      if (disposed) return
+      if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID) || watchdogRescuedSessions.has(sessionID))
+        return
       const goal = await getGoal(sessionID)
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID)) return
       if (goal?.status !== "active" || isPlanAgent(goal.lastPromptAgent)) return
@@ -1433,37 +1572,82 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
       const taskStatus = taskBlockStatus(sessionID)
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID)) return
       if (taskStatus && taskStatus.blocked) return
-      const current = await getGoal(sessionID)
+      const current = await getGoalInternal(sessionID)
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID)) return
       if (current?.status !== "active" || isPlanAgent(current.lastPromptAgent) || activeContinuationsV2.has(sessionID)) return
 
       turnWatchdogs.delete(sessionID)
       activeContinuationsV2.add(sessionID)
       claimedContinuation = true
+      watchdogRescuedSessions.add(sessionID)
       await sendContinuation(sessionID, continuationPrompt(current), current.lastPromptAgent ?? latestStep?.agent ?? null)
+      // Watchdog rescues are untracked retries: a delivered prompt arms the
+      // pending-continuation window but never consumes an auto-turn or
+      // no-progress budget (armNoProgress: false). The rescue delivers while
+      // already busy, so the pending attempt is marked started immediately.
+      await recordContinuationResult(sessionID, "success", maxPromptFailures, { armNoProgress: false, started: true })
+      locallyDeliveredPendingSessions.add(sessionID)
+      clearTurnWatchdog(sessionID)
     } catch (error) {
-      v2ErrorLog("Turn watchdog retry failed", error)
+      try {
+        if (claimedContinuation && isTransportError(error)) {
+          // Watchdog rescues share the same prompt-failure ceiling: recognized
+          // transport errors accumulate toward max_prompt_failures without
+          // consuming auto-turn budgets.
+          await recordContinuationResult(sessionID, "failure", maxPromptFailures)
+        }
+        v2ErrorLog("Turn watchdog retry failed", error)
+      } catch {
+        return
+      }
     } finally {
       if (claimedContinuation) activeContinuationsV2.delete(sessionID)
       if (turnWatchdogs.get(sessionID) === watchdog) turnWatchdogs.delete(sessionID)
     }
   }
 
-  function scheduleSettledContinuation(sessionID: string, delayMs = TASK_SETTLE_DELAY_MS) {
-    if (scheduledContinuations.has(sessionID)) return
-    const timer = setTimeout(() => {
-      scheduledContinuations.delete(sessionID)
-      void runAutoContinue(sessionID, true)
-    }, Math.max(0, delayMs))
-    const maybeUnref = timer as { unref?: () => void }
-    if (typeof maybeUnref.unref === "function") maybeUnref.unref()
-    scheduledContinuations.set(sessionID, timer)
+  function cancelScheduledContinuation(sessionID: string) {
+    const scheduled = scheduledContinuations.get(sessionID)
+    if (scheduled) clearTimeout(scheduled.timer)
+    scheduledContinuations.delete(sessionID)
   }
 
-  async function runAutoContinue(sessionID: string, fromTaskDeferral = false) {
+  function scheduleSettledContinuation(
+    sessionID: string,
+    delayMs = TASK_SETTLE_DELAY_MS,
+    replace = false,
+    purpose: ScheduledContinuation["purpose"] = "settle",
+  ) {
+    if (disposed) return
+    if (!replace && scheduledContinuations.has(sessionID)) return
+    if (replace) cancelScheduledContinuation(sessionID)
+    const scheduled = {} as ScheduledContinuation
+    const timer = setTimeout(async () => {
+      try {
+        if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID)) return
+        if (purpose === "retry") {
+          const goal = await getGoalInternal(sessionID)
+          if (!goal || (goal.continuationFailures === 0 && goal.pendingAttempt == null)) return
+        }
+        if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID)) return
+        await runAutoContinue(sessionID, true, scheduled)
+      } finally {
+        if (scheduledContinuations.get(sessionID) === scheduled) scheduledContinuations.delete(sessionID)
+      }
+    }, Math.max(0, delayMs))
+    scheduled.timer = timer
+    scheduled.purpose = purpose
+    const maybeUnref = timer as { unref?: () => void }
+    if (typeof maybeUnref.unref === "function") maybeUnref.unref()
+    scheduledContinuations.set(sessionID, scheduled)
+  }
+
+  async function runAutoContinue(sessionID: string, fromTaskDeferral = false, scheduled?: ScheduledContinuation) {
+    if (disposed) return
     if (busySessions.has(sessionID)) return
     if (activeContinuationsV2.has(sessionID)) return
     activeContinuationsV2.add(sessionID)
+    let attemptReservedAt = Date.now()
     try {
       const latestStep = latestStepBySession.get(sessionID)
       if (latestStep?.messageID) {
@@ -1472,21 +1656,34 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
       const taskStatus = taskBlockStatus(sessionID)
       if (taskStatus && taskStatus.blocked) {
         taskDeferredSessions.add(sessionID)
-        if (taskStatus.retryAt != null) scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now())
+        if (taskStatus.retryAt != null) {
+          scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now(), scheduled != null)
+        }
         return
       }
       if (busySessions.has(sessionID)) return
       if (latestStep) {
-        await recordAssistantProgress(sessionID, {
+        const beforeProgress = await getGoalInternal(sessionID)
+        const after = await recordAssistantProgress(sessionID, {
           messageID: latestStep.messageID,
           text: latestStep.text,
           outputTokens: latestStep.outputTokens,
           noProgressTokenThreshold: positiveIntegerOrNull(options.no_progress_token_threshold),
           maxNoProgressTurns: positiveIntegerOrNull(options.max_no_progress_turns),
           evaluateContinuation: true,
+          completedAt: latestStep.completedAt,
         })
+        await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, after)
+        const progressed = Boolean(
+          after &&
+            (after.lastAssistantMessageID !== (beforeProgress?.lastAssistantMessageID ?? "") ||
+              after.lastAssistantText !== (beforeProgress?.lastAssistantText ?? "")),
+        )
+        const queuedAfterProgress = scheduledContinuations.get(sessionID)
+        if (progressed && queuedAfterProgress?.purpose !== "settle") cancelScheduledContinuation(sessionID)
       }
-      const current = await getGoal(sessionID)
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled) return
+      const current = await getGoalInternal(sessionID)
       if (!current) return
       const latestTurnAgent = latestStep?.agent
       if (isPlanAgent(current.lastPromptAgent) || isPlanAgent(latestTurnAgent)) {
@@ -1499,16 +1696,86 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
         return
       }
       taskDeferredSessions.delete(sessionID)
+
+      // Pending-continuation resolution (same semantics as V1).
+      const attempt = pendingAttemptOf(current)
+      if (current.status === "active" && attempt != null) {
+        const deliveredLocally = locallyDeliveredPendingSessions.has(sessionID)
+        if (!pendingReadyForFailure(attempt, deliveredLocally)) {
+          return
+        }
+        const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
+          requirePending: true,
+        })
+        if (afterFailure) locallyDeliveredPendingSessions.delete(sessionID)
+        if (autoContinue && afterFailure?.status === "active") {
+          scheduleSettledContinuation(
+            sessionID,
+            continuationRetryDelayMs(minInterval, attempt.reservedAt),
+            true,
+            "retry",
+          )
+        }
+        return
+      }
+
+      const queuedBeforeReserve = scheduledContinuations.get(sessionID)
+      if (queuedBeforeReserve && queuedBeforeReserve !== scheduled) return
+      if (!autoContinue) return
+      if (nativeRetrySessions.has(sessionID)) return
+
       const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval)
       if (!goal) return
+      attemptReservedAt = goal.pendingAttempt?.reservedAt ?? Date.now()
+      if (nativeRetrySessions.has(sessionID)) {
+        await rollbackContinuationAttempt(sessionID)
+        return
+      }
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled) {
+        // Ownership of the scheduled continuation was lost (replaced or
+        // canceled) while we reserved: roll the reserved turn back so it does
+        // not consume an auto-turn.
+        await rollbackContinuationAttempt(sessionID)
+        return
+      }
       await sendContinuation(
         sessionID,
         goal.status === "active" ? continuationPrompt(goal) : limitPrompt(goal),
         goal.lastPromptAgent ?? latestTurnAgent ?? null,
       )
-      await recordContinuationResult(sessionID, "success", maxPromptFailures)
+      if (disposed) {
+        await rollbackContinuationAttempt(sessionID)
+        return
+      }
+      // Delivery succeeded, so commit the attempt even if the timer that
+      // started it was canceled while the prompt was in flight. Rolling back
+      // here would refund an accepted prompt and allow a duplicate on idle.
+      const delivered = await recordContinuationResult(sessionID, "success", maxPromptFailures)
+      locallyDeliveredPendingSessions.add(sessionID)
+      if (!delivered?.pendingAttempt?.delivered) {
+        await rollbackContinuationAttempt(sessionID)
+      }
     } catch (error) {
-      await recordContinuationResult(sessionID, "failure", maxPromptFailures)
+      if (disposed) {
+        // See the V1 catch block: torn down while the prompt was in flight, so
+        // roll back the reserved undelivered attempt without counting a
+        // transport failure or consuming an auto-turn.
+        await rollbackContinuationAttempt(sessionID)
+        return
+      }
+      if (isTransportError(error)) {
+        const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures)
+        if (autoContinue && afterFailure?.status === "active") {
+          scheduleSettledContinuation(
+            sessionID,
+            continuationRetryDelayMs(minInterval, attemptReservedAt),
+            true,
+            "retry",
+          )
+        }
+      } else {
+        await rollbackContinuationAttempt(sessionID)
+      }
       v2ErrorLog("Auto-continue failed", error)
     } finally {
       activeContinuationsV2.delete(sessionID)
@@ -1529,37 +1796,106 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
       case "session.status": {
         const status = data.status
         if (sessionID && isRecord(status) && typeof status.type === "string") {
-          if (status.type === "busy") busySessions.add(sessionID)
-          if (status.type === "busy") armTurnWatchdog(sessionID)
+          if (status.type === "busy") {
+            busySessions.add(sessionID)
+            nativeRetrySessions.delete(sessionID)
+            armTurnWatchdog(sessionID)
+            await markPendingContinuationStarted(sessionID)
+          }
           if (status.type === "idle") {
             busySessions.delete(sessionID)
+            nativeRetrySessions.delete(sessionID)
             clearTurnWatchdog(sessionID)
+            watchdogRescuedSessions.delete(sessionID)
           }
-          if (status.type === "retry") clearTurnWatchdog(sessionID)
+          if (status.type === "retry") {
+            nativeRetrySessions.add(sessionID)
+            clearTurnWatchdog(sessionID)
+            cancelScheduledContinuation(sessionID)
+          }
           taskTracker.observeSessionStatus(sessionID, status.type)
-        }
-        if (autoContinue && sessionID && isRecord(status) && status.type === "idle") {
-          await runAutoContinue(sessionID)
+          if (status.type === "idle") {
+            // Even when auto-continue is disabled, a pending attempt must be
+            // resolved on idle (no-response failures count exactly once, the
+            // same as V1).
+            const goal = await getGoalInternal(sessionID)
+            if (autoContinue || goal?.pendingAttempt != null) await runAutoContinue(sessionID)
+          }
         }
         return
       }
       case "session.idle": {
         if (sessionID) {
           busySessions.delete(sessionID)
+          nativeRetrySessions.delete(sessionID)
           clearTurnWatchdog(sessionID)
+          watchdogRescuedSessions.delete(sessionID)
           taskTracker.observeSessionStatus(sessionID, "idle")
         }
-        if (autoContinue && sessionID) await runAutoContinue(sessionID)
+        if (sessionID) {
+          // Resolution of a pending attempt runs even when auto-continue is
+          // disabled (see the session.status idle branch above).
+          const goal = await getGoalInternal(sessionID)
+          if (autoContinue || goal?.pendingAttempt != null) await runAutoContinue(sessionID)
+        }
+        return
+      }
+      case "session.error": {
+        if (!sessionID) return
+        const inNativeRetry = nativeRetrySessions.has(sessionID)
+        busySessions.delete(sessionID)
+        clearTurnWatchdog(sessionID)
+        // Same policy as V1: a native provider retry episode is already
+        // recovering, so a transport error inside it must not schedule plugin
+        // recovery, and the marker stays until busy/idle ends the episode.
+        if (inNativeRetry) return
+        nativeRetrySessions.delete(sessionID)
+        watchdogRescuedSessions.delete(sessionID)
+        const errorMessage = transportErrorMessageFromEvent(data)
+        if (errorMessage && isTransportError(errorMessage)) {
+          const goal = await getGoalInternal(sessionID)
+          if (goal?.status === "active") {
+            const attempt = pendingAttemptOf(goal)
+            if (attempt != null) {
+              const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
+                requirePending: true,
+              })
+              if (afterFailure) locallyDeliveredPendingSessions.delete(sessionID)
+              if (autoContinue && afterFailure?.status === "active") {
+                scheduleSettledContinuation(
+                  sessionID,
+                  continuationRetryDelayMs(minInterval, attempt.reservedAt),
+                  true,
+                  "retry",
+                )
+              }
+            } else if (autoContinue) {
+              // No pending attempt: start the first bounded automatic recovery
+              // without charging a phantom failure. Duplicate transport events
+              // dedupe through the scheduled-continuation timer.
+              scheduleSettledContinuation(
+                sessionID,
+                continuationDelayFromSnapshot(minInterval, goal.lastContinuationAt),
+                false,
+                "recovery",
+              )
+            }
+          }
+        }
         return
       }
       case "session.deleted": {
         if (!sessionID) return
         busySessions.delete(sessionID)
         clearTurnWatchdog(sessionID)
+        watchdogRescuedSessions.delete(sessionID)
+        locallyDeliveredPendingSessions.delete(sessionID)
+        nativeRetrySessions.delete(sessionID)
         const scheduled = scheduledContinuations.get(sessionID)
-        if (scheduled) clearTimeout(scheduled)
+        if (scheduled) clearTimeout(scheduled.timer)
         scheduledContinuations.delete(sessionID)
         taskDeferredSessions.delete(sessionID)
+        clearToolAttemptsForSession(toolAttempts, sessionID)
         taskTracker.observeSessionDeleted(sessionID)
         latestStepBySession.delete(sessionID)
         stepTokenSums.delete(sessionID)
@@ -1581,7 +1917,7 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
           info: { id: messageID, role: "assistant", time: { completed: event.created } },
         })
         if (!stepTextBuffers.has(stepKey(sessionID, messageID))) stepTextBuffers.set(stepKey(sessionID, messageID), "")
-        latestStepBySession.set(sessionID, { messageID, agent, text: "", outputTokens: null })
+        latestStepBySession.set(sessionID, { messageID, agent, text: "", outputTokens: null, completedAt: event.created })
         return
       }
       case "session.text.delta": {
@@ -1609,18 +1945,27 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
         const text = stepTextBuffers.get(stepKey(sessionID, messageID)) ?? ""
         stepTextBuffers.delete(stepKey(sessionID, messageID))
         const outputTokens = outputTokensFromRecord(data.tokens) ?? null
-        await recordAssistantProgress(sessionID, {
+        const afterStep = await recordAssistantProgress(sessionID, {
           messageID,
           text,
           outputTokens,
           noProgressTokenThreshold: positiveIntegerOrNull(options.no_progress_token_threshold),
           maxNoProgressTurns: positiveIntegerOrNull(options.max_no_progress_turns),
+          completedAt: event.created,
         })
+        await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, afterStep)
+        // Substantive output from the model proves the transport recovered, so
+        // any pending automatic recovery timer is no longer needed.
+        if (/[\p{L}\p{N}]/u.test(text)) {
+          const scheduled = scheduledContinuations.get(sessionID)
+          if (scheduled?.purpose === "recovery") cancelScheduledContinuation(sessionID)
+        }
         latestStepBySession.set(sessionID, {
           messageID,
           agent: latestStepBySession.get(sessionID)?.agent,
           text,
           outputTokens,
+          completedAt: event.created,
         })
         return
       }
@@ -1636,18 +1981,25 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
         const text = stepTextBuffers.get(stepKey(sessionID, messageID)) ?? ""
         stepTextBuffers.delete(stepKey(sessionID, messageID))
         const outputTokens = outputTokensFromRecord(data.tokens) ?? null
-        await recordAssistantProgress(sessionID, {
+        const afterStep = await recordAssistantProgress(sessionID, {
           messageID,
           text,
           outputTokens,
           noProgressTokenThreshold: positiveIntegerOrNull(options.no_progress_token_threshold),
           maxNoProgressTurns: positiveIntegerOrNull(options.max_no_progress_turns),
+          completedAt: event.created,
         })
+        await reconcileLocalMarkerAfterProgress(locallyDeliveredPendingSessions, sessionID, afterStep)
+        if (/[\p{L}\p{N}]/u.test(text)) {
+          const scheduled = scheduledContinuations.get(sessionID)
+          if (scheduled?.purpose === "recovery") cancelScheduledContinuation(sessionID)
+        }
         latestStepBySession.set(sessionID, {
           messageID,
           agent: latestStepBySession.get(sessionID)?.agent,
           text,
           outputTokens,
+          completedAt: event.created,
         })
         return
       }
@@ -1679,18 +2031,48 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
   )
 
   registrations.push(
-    await context.tool.hook("execute.before", (input) => {
+    await context.tool.hook("execute.before", async (input) => {
       taskTracker.noteTaskCall({ tool: input.tool, sessionID: input.sessionID, callID: input.id })
+      const sessionID = typeof input.sessionID === "string" ? input.sessionID : undefined
+      const callID = typeof input.id === "string" ? input.id : undefined
+      if (sessionID && callID) {
+        const goal = await getGoalInternal(sessionID)
+        toolAttempts.set(toolAttemptKey(sessionID, callID), goal?.pendingAttempt?.id ?? null)
+      }
     }),
   )
 
   registrations.push(
-    await context.tool.hook("execute.after", (input) => {
+    await context.tool.hook("execute.after", async (input) => {
+      const sessionID = typeof input.sessionID === "string" ? input.sessionID : undefined
+      const callID = typeof input.id === "string" ? input.id : undefined
+      const attemptKey = sessionID && callID ? toolAttemptKey(sessionID, callID) : undefined
+      const expectedAttemptID = attemptKey ? toolAttempts.get(attemptKey) : undefined
+      if (attemptKey) toolAttempts.delete(attemptKey)
       if (input.status !== "completed") return
+      const text = textFromToolResult(input.result)
       taskTracker.noteTaskOutput(
         { tool: input.tool, sessionID: input.sessionID, callID: input.id },
         { output: textFromToolResult(input.result) },
       )
+      // A successful tool output is real progress: it resolves any pending
+      // continuation and clears the prompt-failure counter. This body is async
+      // so recovery cancellation completes before any pending recovery timer.
+      if (!sessionID || typeof input.tool !== "string") return
+      if (NON_PROGRESS_TOOLS.has(input.tool.toLowerCase())) return
+      if (toolOutputFailed(input.result)) return
+      if (!text) return
+      const before = await getGoalInternal(sessionID)
+      const scheduled = scheduledContinuations.get(sessionID)
+      const hasFailureEpisode = Boolean(
+        before && (before.continuationFailures > 0 || before.pendingAttempt != null),
+      )
+      if (!before || (!hasFailureEpisode && scheduled?.purpose !== "recovery")) return
+      const progressed = await recordToolProgress(sessionID, text, expectedAttemptID)
+      if (progressed?.continuationFailures === 0 && progressed.pendingAttempt == null) {
+        locallyDeliveredPendingSessions.delete(sessionID)
+        cancelScheduledContinuation(sessionID)
+      }
     }),
   )
 
@@ -1720,12 +2102,17 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
   })()
 
   return async () => {
+    disposed = true
     abortController.abort()
-    for (const timer of scheduledContinuations.values()) clearTimeout(timer)
+    for (const scheduled of scheduledContinuations.values()) clearTimeout(scheduled.timer)
     scheduledContinuations.clear()
     for (const watchdog of turnWatchdogs.values()) clearTimeout(watchdog.timer)
     turnWatchdogs.clear()
     activeContinuationsV2.clear()
+    nativeRetrySessions.clear()
+    locallyDeliveredPendingSessions.clear()
+    watchdogRescuedSessions.clear()
+    toolAttempts.clear()
     for (const registration of registrations) await registration.dispose()
     // Best-effort termination of the event consumer. Never block plugin
     // unload on a stream that does not close promptly.

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,8 @@ import {
   recordAssistantProgress,
   recordContinuationResult,
   recordPromptAgent,
+  recordToolProgress,
+  markPendingContinuationStarted,
   reserveContinuation,
   setGoalStatus,
   updateGoalObjective,
@@ -64,6 +66,12 @@ const DEFAULT_RESTRICTED_AGENTS = ["plan"]
 const TASK_SETTLE_DELAY_MS = 25
 const SNAPSHOT_IDLE_HOLD_MS = 250
 const MAX_TIMER_DELAY_MS = 2_147_483_647
+const STALE_PENDING_MS = 30_000
+const RETRY_SETTLE_MS = 25
+const TRANSPORT_ERROR_PATTERN =
+  /\b(?:network|fetch|socket|connect|connection|timeout|timed out|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|EPIPE|transport|stream|websocket|offline|internet|request failed|proxy)\b/i
+const NON_TRANSPORT_TERMINAL_PATTERN = /\b(?:abort(?:ed)?|interrupt(?:ed|ion)?)\b/i
+const NON_PROGRESS_TOOLS = new Set(["get_goal", "get_goal_history"])
 const TASK_TERMINAL_STATES = new Set<TaskState>(["completed", "error", "cancelled"])
 const PLAN_MODE_CREATE_NOTICE =
   'Goal recorded while the session is in Plan mode, so execution is paused. Do not start implementation work now. Ask the user to switch to Build mode and resume the goal (for example with "/goal resume") to begin execution.'
@@ -100,6 +108,11 @@ type SnapshotIdleHold = {
 
 type TurnWatchdog = {
   timer: ReturnType<typeof setTimeout>
+}
+
+type ScheduledContinuation = {
+  timer: ReturnType<typeof setTimeout>
+  purpose: "settle" | "recovery" | "retry"
 }
 
 function restrictedAgentSet(options?: Options) {
@@ -140,6 +153,10 @@ function commandNameFromOptions(options?: Options) {
 
 function positiveIntegerOrNull(value: unknown) {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : null
+}
+
+function nonNegativeIntegerOrNull(value: unknown) {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : null
 }
 
 function timeoutMillisecondsFromSeconds(value: unknown) {
@@ -303,6 +320,80 @@ function isIdleEvent(event: { type?: string; properties?: Record<string, unknown
   if (event.type === "session.idle") return true
   const status = event.properties?.status
   return event.type === "session.status" && typeof status === "object" && status !== null && (status as { type?: unknown }).type === "idle"
+}
+
+function isTransportError(error: unknown) {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : ""
+  if (!message || NON_TRANSPORT_TERMINAL_PATTERN.test(message)) return false
+  if (TRANSPORT_ERROR_PATTERN.test(message)) return true
+  return false
+}
+
+function transportErrorMessageFromEvent(props: Record<string, unknown>) {
+  for (const candidate of [props.error, props.message, props.reason]) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim()
+    if (isRecord(candidate)) {
+      for (const key of ["message", "error", "reason", "description"]) {
+        const value = candidate[key]
+        if (typeof value === "string" && value.trim()) return value.trim()
+      }
+    }
+  }
+  return ""
+}
+
+// Retry after the remaining minimum interval measured from the attempt's
+// millisecond anchor. The public lastContinuationAt field remains in seconds.
+function continuationRetryDelayMs(minIntervalSeconds: number, attemptAt: number, now = Date.now()) {
+  return Math.max(0, attemptAt + minIntervalSeconds * 1000 - now) + RETRY_SETTLE_MS
+}
+
+function continuationDelayFromSnapshot(minIntervalSeconds: number, lastContinuationAt: number | null, now = Date.now()) {
+  if (lastContinuationAt == null) return RETRY_SETTLE_MS
+  // lastContinuationAt is floor(seconds), so include the remainder of that
+  // second to guarantee reserveContinuation cannot wake too early and wedge.
+  return Math.max(0, (lastContinuationAt + minIntervalSeconds + 1) * 1000 - now) + RETRY_SETTLE_MS
+}
+
+const TOOL_FAILURE_STATES = new Set([
+  "failed",
+  "failure",
+  "error",
+  "cancelled",
+  "canceled",
+  "aborted",
+  "abort",
+  "interrupted",
+  "running",
+  "pending",
+  "in_progress",
+  "in-progress",
+  "incomplete",
+  "partial",
+  "timeout",
+  "timed_out",
+])
+
+function toolOutputFailed(output: unknown) {
+  if (!isRecord(output)) return true
+  if (typeof output.error === "string" && output.error.trim()) return true
+  if (output.success === false) return true
+  const text = typeof output.output === "string" ? output.output.trim() : ""
+  const state = output.state ?? output.status
+  if (typeof state === "string") {
+    const normalized = state.trim().toLowerCase()
+    if (TOOL_FAILURE_STATES.has(normalized)) return true
+    if (["completed", "complete", "success", "succeeded", "ok", "done"].includes(normalized)) return false
+  }
+  if (isRecord(output.metadata)) {
+    const metaState = output.metadata.state ?? output.metadata.status
+    if (typeof metaState === "string" && TOOL_FAILURE_STATES.has(metaState.trim().toLowerCase())) return true
+  }
+  const taskState = parseTaskState(text)
+  if (taskState) return taskState !== "completed"
+  if (/^state:\s*(failed|failure|error|cancelled|canceled|aborted|abort|interrupted|running|pending|incomplete|partial|timeout|timed_out)\b/im.test(text)) return true
+  if (/^<error>/i.test(text) || /^<tool-error>/i.test(text) || /^error:/i.test(text)) return true
+  return false
 }
 
 function sessionIDFromEvent(event: { type?: string; properties?: Record<string, unknown> }) {
@@ -596,15 +687,22 @@ async function recordAssistantMessage(
   options: Options,
   evaluateContinuation = false,
 ) {
-  if (!message) return
-  await recordAssistantProgress(sessionID, {
-    messageID: messageID(message),
-    text: textFromMessage(message),
+  if (!message) return { goal: null, progressed: false }
+  const before = await getGoal(sessionID)
+  const id = messageID(message) ?? ""
+  const text = textFromMessage(message)
+  const progressed = Boolean(
+    /[\p{L}\p{N}]/u.test(text) && (id !== (before?.lastAssistantMessageID ?? "") || text !== (before?.lastAssistantText ?? "")),
+  )
+  const goal = await recordAssistantProgress(sessionID, {
+    messageID: id,
+    text,
     outputTokens: outputTokensFromMessage(message) ?? null,
     noProgressTokenThreshold: positiveIntegerOrNull(options.no_progress_token_threshold),
     maxNoProgressTurns: positiveIntegerOrNull(options.max_no_progress_turns),
     evaluateContinuation,
   })
+  return { goal, progressed }
 }
 
 function mergeSystemReminder(output: { system: string[] }, reminder: string) {
@@ -629,16 +727,22 @@ const server: Plugin = async ({ client }, options?: Options) => {
   const autoContinue = options?.auto_continue ?? true
   const deferWhileTasksActive = options?.defer_while_tasks_active ?? true
   const maxAutoTurns = positiveIntegerOrNull(options?.max_auto_turns) ?? DEFAULT_MAX_AUTO_TURNS
-  const minInterval = positiveIntegerOrNull(options?.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS
+  const minInterval = nonNegativeIntegerOrNull(options?.min_continue_interval_seconds) ?? DEFAULT_CONTINUE_INTERVAL_SECONDS
   const maxTurnTimeMs = timeoutMillisecondsFromSeconds(options?.max_turn_time)
   const maxPromptFailures = positiveIntegerOrNull(options?.max_prompt_failures) ?? DEFAULT_MAX_PROMPT_FAILURES
   const registerCommand = options?.register_command ?? true
   const commandName = commandNameFromOptions(options)
   const taskTracker = new TaskTracker()
   const taskDeferredSessions = new Set<string>()
-  const scheduledContinuations = new Map<string, ReturnType<typeof setTimeout>>()
+  const scheduledContinuations = new Map<string, ScheduledContinuation>()
   const turnWatchdogs = new Map<string, TurnWatchdog>()
   const busySessions = new Set<string>()
+  const nativeRetrySessions = new Set<string>()
+  const locallyDeliveredPendingSessions = new Set<string>()
+  // Sessions whose busy episode already received a watchdog rescue. Cleared
+  // when the episode ends (idle/deleted), so each busy episode rescues at most
+  // once and a rescue prompt cannot recursively re-arm the watchdog.
+  const watchdogRescuedSessions = new Set<string>()
   const planAgents = restrictedAgentSet(options)
   const isPlanAgent = (agent: unknown) => typeof agent === "string" && planAgents.has(agent.trim().toLowerCase())
 
@@ -674,6 +778,7 @@ const server: Plugin = async ({ client }, options?: Options) => {
 
   function armTurnWatchdog(sessionID: string) {
     if (maxTurnTimeMs == null) return
+    if (watchdogRescuedSessions.has(sessionID)) return
     clearTurnWatchdog(sessionID)
     const watchdog: TurnWatchdog = {
       timer: setTimeout(() => void runTurnWatchdog(sessionID, watchdog), maxTurnTimeMs),
@@ -686,7 +791,12 @@ const server: Plugin = async ({ client }, options?: Options) => {
   async function runTurnWatchdog(sessionID: string, watchdog: TurnWatchdog) {
     let claimedContinuation = false
     try {
-      if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID)) return
+      if (
+        turnWatchdogs.get(sessionID) !== watchdog ||
+        !busySessions.has(sessionID) ||
+        watchdogRescuedSessions.has(sessionID)
+      )
+        return
       const goal = await getGoal(sessionID)
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID)) return
       if (goal?.status !== "active" || isPlanAgent(goal.lastPromptAgent)) return
@@ -694,6 +804,9 @@ const server: Plugin = async ({ client }, options?: Options) => {
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID)) return
       const latestTurnAgent = agentFromMessage(latestAssistant)
       if (isPlanAgent(latestTurnAgent)) return
+      // Establish the pre-rescue baseline so this same historical message
+      // cannot later be mistaken for progress from the rescue prompt.
+      await recordAssistantMessage(sessionID, latestAssistant, options ?? {})
       const taskStatus = await taskBlockStatus(sessionID)
       if (turnWatchdogs.get(sessionID) !== watchdog || !busySessions.has(sessionID)) return
       if (taskStatus && taskStatus.blocked) return
@@ -704,9 +817,24 @@ const server: Plugin = async ({ client }, options?: Options) => {
       turnWatchdogs.delete(sessionID)
       activeContinuations.add(sessionID)
       claimedContinuation = true
+      watchdogRescuedSessions.add(sessionID)
       await sendContinuation(client, sessionID, continuationPrompt(current), current.lastPromptAgent ?? latestTurnAgent ?? null)
+      // Watchdog rescues are untracked retries: a delivered prompt arms the
+      // pending-continuation window but never consumes an auto-turn budget and
+      // never arms the no-progress evaluation. The rescue delivers while the
+      // session is already inside a busy episode, so the pending attempt is
+      // marked started immediately, and this busy episode rescues only once.
+      await recordContinuationResult(sessionID, "success", maxPromptFailures, { armNoProgress: false, started: true })
+      locallyDeliveredPendingSessions.add(sessionID)
+      clearTurnWatchdog(sessionID)
     } catch (error) {
       try {
+        // Watchdog rescues share the same prompt-failure ceiling: recognized
+        // transport errors accumulate toward max_prompt_failures without
+        // consuming auto-turn budgets.
+        if (claimedContinuation && isTransportError(error)) {
+          await recordContinuationResult(sessionID, "failure", maxPromptFailures)
+        }
         await client.app?.log?.({
           body: {
             service: "opencode-goal-plugin",
@@ -724,18 +852,47 @@ const server: Plugin = async ({ client }, options?: Options) => {
     }
   }
 
-  function scheduleSettledContinuation(sessionID: string, delayMs = TASK_SETTLE_DELAY_MS) {
-    if (scheduledContinuations.has(sessionID)) return
-    const timer = setTimeout(() => {
-      scheduledContinuations.delete(sessionID)
-      void runAutoContinue(sessionID, true)
-    }, Math.max(0, delayMs))
-    const maybeUnref = timer as { unref?: () => void }
-    if (typeof maybeUnref.unref === "function") maybeUnref.unref()
-    scheduledContinuations.set(sessionID, timer)
+  function cancelScheduledContinuation(sessionID: string) {
+    const scheduled = scheduledContinuations.get(sessionID)
+    if (scheduled) clearTimeout(scheduled.timer)
+    scheduledContinuations.delete(sessionID)
   }
 
-  async function runAutoContinue(sessionID: string, fromTaskDeferral = false) {
+  function scheduleSettledContinuation(
+    sessionID: string,
+    delayMs = TASK_SETTLE_DELAY_MS,
+    replace = false,
+    purpose: ScheduledContinuation["purpose"] = "settle",
+  ) {
+    if (!replace && scheduledContinuations.has(sessionID)) return
+    if (replace) cancelScheduledContinuation(sessionID)
+    const scheduled = {} as ScheduledContinuation
+    const timer = setTimeout(async () => {
+      try {
+        if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID)) return
+        if (purpose === "retry") {
+          const goal = await getGoal(sessionID)
+          if (!goal || (goal.continuationFailures === 0 && goal.pendingContinuationStart == null)) return
+        }
+        if (scheduledContinuations.get(sessionID) !== scheduled || nativeRetrySessions.has(sessionID)) return
+        await runAutoContinue(sessionID, true, scheduled)
+      } finally {
+        if (scheduledContinuations.get(sessionID) === scheduled) scheduledContinuations.delete(sessionID)
+      }
+    }, Math.max(0, delayMs))
+    scheduled.timer = timer
+    scheduled.purpose = purpose
+    const maybeUnref = timer as { unref?: () => void }
+    if (typeof maybeUnref.unref === "function") maybeUnref.unref()
+    scheduledContinuations.set(sessionID, scheduled)
+  }
+
+  async function runAutoContinue(
+    sessionID: string,
+    fromTaskDeferral = false,
+    scheduled?: ScheduledContinuation,
+  ) {
+    let reservedAt: number | null = null
     if (busySessions.has(sessionID)) return
     if (activeContinuations.has(sessionID)) return
     activeContinuations.add(sessionID)
@@ -745,11 +902,16 @@ const server: Plugin = async ({ client }, options?: Options) => {
       const taskStatus = await taskBlockStatus(sessionID)
       if (taskStatus && taskStatus.blocked) {
         taskDeferredSessions.add(sessionID)
-        if (taskStatus.retryAt != null) scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now())
+        if (taskStatus.retryAt != null) {
+          scheduleSettledContinuation(sessionID, taskStatus.retryAt - Date.now(), scheduled != null)
+        }
         return
       }
       if (busySessions.has(sessionID)) return
-      await recordAssistantMessage(sessionID, latestAssistant, options ?? {}, true)
+      const observed = await recordAssistantMessage(sessionID, latestAssistant, options ?? {}, true)
+      const queued = scheduledContinuations.get(sessionID)
+      if (observed.progressed && queued?.purpose !== "settle") cancelScheduledContinuation(sessionID)
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled) return
       const current = await getGoal(sessionID)
       if (!current) return
       const latestTurnAgent = agentFromMessage(latestAssistant)
@@ -763,8 +925,48 @@ const server: Plugin = async ({ client }, options?: Options) => {
         return
       }
       taskDeferredSessions.delete(sessionID)
+
+      // Pending-continuation resolution. A delivered prompt is armed with
+      // started=false until a session.status busy event marks it started.
+      // Paired duplicate idles before any busy must never count a failure or
+      // send a duplicate, so started=false attempts are left alone until they
+      // go stale (restart recovery). Once started, the following logical idle
+      // with no substantive progress counts exactly one unresolved failure and
+      // schedules a bounded retry at the remaining min interval.
+      if (current.status === "active" && current.pendingContinuationStart != null) {
+        const pendingAgeMs = Date.now() - current.pendingContinuationStart
+        const deliveredLocally = locallyDeliveredPendingSessions.has(sessionID)
+        if (!current.pendingContinuationStarted && (deliveredLocally || pendingAgeMs < STALE_PENDING_MS)) {
+          return
+        }
+        const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
+          requirePending: true,
+        })
+        if (afterFailure) locallyDeliveredPendingSessions.delete(sessionID)
+        if (autoContinue && afterFailure?.status === "active") {
+          scheduleSettledContinuation(
+            sessionID,
+            continuationRetryDelayMs(minInterval, current.pendingContinuationStart),
+            true,
+            "retry",
+          )
+        }
+        return
+      }
+
+      // A retry or recovery timer is already scheduled for this session (for
+      // example from a paired idle after an unresolved failure); let that timer
+      // drive the next attempt instead of sending a duplicate now.
+      const queuedBeforeReserve = scheduledContinuations.get(sessionID)
+      if (queuedBeforeReserve && queuedBeforeReserve !== scheduled) return
+      if (!autoContinue) return
+      if (nativeRetrySessions.has(sessionID)) return
+
       const goal = await reserveContinuation(sessionID, maxAutoTurns, minInterval)
       if (!goal) return
+      if (nativeRetrySessions.has(sessionID)) return
+      if (scheduled && scheduledContinuations.get(sessionID) !== scheduled) return
+      reservedAt = Date.now()
       await sendContinuation(
         client,
         sessionID,
@@ -772,8 +974,12 @@ const server: Plugin = async ({ client }, options?: Options) => {
         goal.lastPromptAgent ?? latestTurnAgent ?? null,
       )
       await recordContinuationResult(sessionID, "success", maxPromptFailures)
+      locallyDeliveredPendingSessions.add(sessionID)
     } catch (error) {
-      await recordContinuationResult(sessionID, "failure", maxPromptFailures)
+      const afterFailure = reservedAt == null ? null : await recordContinuationResult(sessionID, "failure", maxPromptFailures)
+      if (isTransportError(error) && autoContinue && reservedAt != null && afterFailure?.status === "active") {
+        scheduleSettledContinuation(sessionID, continuationRetryDelayMs(minInterval, reservedAt), true, "retry")
+      }
       await client.app?.log?.({
         body: {
           service: "opencode-goal-plugin",
@@ -789,10 +995,13 @@ const server: Plugin = async ({ client }, options?: Options) => {
 
   return {
     async dispose() {
-      for (const timer of scheduledContinuations.values()) clearTimeout(timer)
+      for (const scheduled of scheduledContinuations.values()) clearTimeout(scheduled.timer)
       scheduledContinuations.clear()
       for (const watchdog of turnWatchdogs.values()) clearTimeout(watchdog.timer)
       turnWatchdogs.clear()
+      watchdogRescuedSessions.clear()
+      locallyDeliveredPendingSessions.clear()
+      nativeRetrySessions.clear()
     },
     async config(config) {
       if (!registerCommand) return
@@ -922,6 +1131,27 @@ const server: Plugin = async ({ client }, options?: Options) => {
         input as { tool?: unknown; sessionID?: unknown; callID?: unknown },
         output as { output?: unknown },
       )
+      const sessionID = typeof input?.sessionID === "string" ? input.sessionID : undefined
+      if (!sessionID) return
+      if (typeof input?.tool === "string" && NON_PROGRESS_TOOLS.has(input.tool.toLowerCase())) return
+      const toolResult = output as { output?: unknown; error?: unknown }
+      // A successful tool output is real progress: it resolves any pending
+      // continuation and clears the prompt-failure counter. Failed tool
+      // outputs leave the failure counter and pending window untouched.
+      if (toolOutputFailed(toolResult)) return
+      const text = typeof toolResult.output === "string" ? toolResult.output : undefined
+      if (!text) return
+      const before = await getGoal(sessionID)
+      const scheduled = scheduledContinuations.get(sessionID)
+      const hasFailureEpisode = Boolean(
+        before && (before.continuationFailures > 0 || before.pendingContinuationStart != null),
+      )
+      if (!before || (!hasFailureEpisode && scheduled?.purpose !== "recovery")) return
+      const progressed = await recordToolProgress(sessionID, text)
+      if (progressed?.continuationFailures === 0 && progressed.pendingContinuationStart == null) {
+        locallyDeliveredPendingSessions.delete(sessionID)
+        cancelScheduledContinuation(sessionID)
+      }
     },
     async "chat.message"(input, output) {
       const sessionID = typeof input?.sessionID === "string" ? input.sessionID : output.message?.sessionID
@@ -937,7 +1167,9 @@ const server: Plugin = async ({ client }, options?: Options) => {
           : output.messages.find((message) => typeof message.info.sessionID === "string")?.info.sessionID
       if (!sessionID) return
       await accountUsage(sessionID, tokensFromMessages(output.messages))
-      await recordAssistantMessage(sessionID, latestAssistantMessage(output.messages), options ?? {})
+      const observed = await recordAssistantMessage(sessionID, latestAssistantMessage(output.messages), options ?? {})
+      const scheduled = scheduledContinuations.get(sessionID)
+      if (observed.progressed && scheduled?.purpose !== "settle") cancelScheduledContinuation(sessionID)
     },
     async "experimental.chat.system.transform"(input, output) {
       if (typeof input.sessionID !== "string") return
@@ -961,27 +1193,79 @@ const server: Plugin = async ({ client }, options?: Options) => {
       if (sessionID && eventType === "session.status") {
         const status = (event as { properties?: Record<string, unknown> }).properties?.status
         if (isRecord(status) && typeof status.type === "string") {
-          if (status.type === "busy") busySessions.add(sessionID)
+          if (status.type === "busy") {
+            busySessions.add(sessionID)
+            nativeRetrySessions.delete(sessionID)
+          }
           if (status.type === "busy") armTurnWatchdog(sessionID)
+          if (status.type === "busy") await markPendingContinuationStarted(sessionID)
           if (status.type === "idle") {
             busySessions.delete(sessionID)
+            nativeRetrySessions.delete(sessionID)
             clearTurnWatchdog(sessionID)
+            watchdogRescuedSessions.delete(sessionID)
           }
-          if (status.type === "retry") clearTurnWatchdog(sessionID)
+          if (status.type === "retry") {
+            nativeRetrySessions.add(sessionID)
+            clearTurnWatchdog(sessionID)
+            cancelScheduledContinuation(sessionID)
+          }
           taskTracker.observeSessionStatus(sessionID, status.type)
         }
       }
       if (sessionID && eventType === "session.idle") {
         busySessions.delete(sessionID)
+        nativeRetrySessions.delete(sessionID)
         clearTurnWatchdog(sessionID)
+        watchdogRescuedSessions.delete(sessionID)
         taskTracker.observeSessionStatus(sessionID, "idle")
+      }
+      if (sessionID && eventType === "session.error") {
+        busySessions.delete(sessionID)
+        nativeRetrySessions.delete(sessionID)
+        clearTurnWatchdog(sessionID)
+        watchdogRescuedSessions.delete(sessionID)
+        const props = (event as { properties?: Record<string, unknown> }).properties ?? {}
+        const errorMessage = transportErrorMessageFromEvent(props)
+        if (errorMessage && isTransportError(errorMessage)) {
+          const goal = await getGoal(sessionID)
+          if (goal?.status === "active") {
+            if (goal.pendingContinuationStart != null) {
+              // The pending attempt failed at the transport level: count one
+              // failure and retry at the remaining min interval.
+              const afterFailure = await recordContinuationResult(sessionID, "failure", maxPromptFailures, {
+                requirePending: true,
+              })
+              if (afterFailure) locallyDeliveredPendingSessions.delete(sessionID)
+              if (autoContinue && afterFailure?.status === "active") {
+                scheduleSettledContinuation(
+                  sessionID,
+                  continuationRetryDelayMs(minInterval, goal.pendingContinuationStart),
+                  true,
+                  "retry",
+                )
+              }
+            } else if (autoContinue) {
+              // No pending attempt: start the first bounded automatic recovery
+              // without charging a phantom failure. Duplicate transport events
+              // dedupe through the scheduled-continuation timer.
+              scheduleSettledContinuation(
+                sessionID,
+                continuationDelayFromSnapshot(minInterval, goal.lastContinuationAt),
+                false,
+                "recovery",
+              )
+            }
+          }
+        }
       }
       if (sessionID && eventType === "session.deleted") {
         busySessions.delete(sessionID)
         clearTurnWatchdog(sessionID)
-        const scheduled = scheduledContinuations.get(sessionID)
-        if (scheduled) clearTimeout(scheduled)
-        scheduledContinuations.delete(sessionID)
+        watchdogRescuedSessions.delete(sessionID)
+        locallyDeliveredPendingSessions.delete(sessionID)
+        nativeRetrySessions.delete(sessionID)
+        cancelScheduledContinuation(sessionID)
         taskDeferredSessions.delete(sessionID)
         taskTracker.observeSessionDeleted(sessionID)
       }
@@ -991,11 +1275,14 @@ const server: Plugin = async ({ client }, options?: Options) => {
           | { info?: unknown; role?: unknown; id?: unknown; time?: unknown; parts?: unknown[] }
           | undefined
         taskTracker.observeAssistantMessage(sessionID, message)
-        await recordAssistantMessage(sessionID, message, options ?? {})
+        const observed = await recordAssistantMessage(sessionID, message, options ?? {})
+        const scheduled = scheduledContinuations.get(sessionID)
+        if (observed.progressed && scheduled?.purpose !== "settle") cancelScheduledContinuation(sessionID)
       }
 
-      if (!autoContinue || !isIdleEvent(event as never)) return
+      if (!isIdleEvent(event as never)) return
       if (!sessionID) return
+      if (!autoContinue && (await getGoal(sessionID))?.pendingContinuationStart == null) return
       await runAutoContinue(sessionID)
     },
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -47,6 +47,32 @@ export type AssistantProgressInput = {
   noProgressTokenThreshold?: number | null
   maxNoProgressTurns?: number | null
   evaluateContinuation?: boolean
+  /** Millisecond completedAt of the assistant message, for correlating progress to the current attempt. */
+  completedAt?: number | null
+}
+
+/**
+ * A single automatic-continuation attempt. It is persisted BEFORE the prompt
+ * is delivered so that out-of-band events (a session status "busy" that races
+ * the prompt resolution) can correlate to the correct attempt instead of
+ * relying on local-only function timing. The attempt is internal: it is never
+ * exposed on the public GoalSnapshot / tool JSON.
+ */
+export type PendingAttempt = {
+  /** Stable identity for the attempt, used to correlate busy/error/progress events. */
+  id: string
+  /** Millisecond timestamp used as the minimum-interval and staleness anchor. */
+  reservedAt: number
+  /** The provider picked the prompt up (a session.status busy fired). */
+  started: boolean
+  /** The prompt was confirmed delivered (promptAsync / session.prompt resolved). */
+  delivered: boolean
+  /** autoTurns / lastContinuationAt were committed for this attempt. */
+  committed: boolean
+  /** Whether the delivered prompt should arm the no-progress evaluation. */
+  armNoProgress: boolean
+  /** lastContinuationAt value to restore if this unconsumed attempt is rolled back. */
+  previousLastContinuationAt: number | null
 }
 
 export type Goal = {
@@ -65,8 +91,7 @@ export type Goal = {
   autoTurns: number
   lastContinuationAt: number | null
   continuationFailures: number
-  pendingContinuationStart: number | null
-  pendingContinuationStarted: boolean
+  pendingAttempt: PendingAttempt | null
   lastStatus: string | null
   maxAutoTurns: number | null
   maxDurationSeconds: number | null
@@ -134,6 +159,15 @@ const CheckpointSchema = Schema.Struct({
   summary: Schema.String,
   timestamp: Schema.Number,
 })
+const PendingAttemptSchema = Schema.Struct({
+  id: Schema.String,
+  reservedAt: Schema.Number,
+  started: Schema.Boolean,
+  delivered: Schema.Boolean,
+  committed: Schema.Boolean,
+  armNoProgress: Schema.Boolean,
+  previousLastContinuationAt: Schema.NullOr(Schema.Number),
+})
 const GoalSchema = Schema.Struct({
   sessionID: Schema.String,
   objective: Schema.String,
@@ -150,8 +184,7 @@ const GoalSchema = Schema.Struct({
   autoTurns: Schema.Number,
   lastContinuationAt: NullableNumber,
   continuationFailures: Schema.optionalWith(Schema.Number, { default: () => 0 }),
-  pendingContinuationStart: Schema.optionalWith(NullableNumber, { default: () => null }),
-  pendingContinuationStarted: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+  pendingAttempt: Schema.optionalWith(Schema.NullOr(PendingAttemptSchema), { default: () => null }),
   lastStatus: Schema.optionalWith(NullableString, { default: () => null }),
   maxAutoTurns: Schema.optionalWith(NullableNumber, { default: () => null }),
   maxDurationSeconds: Schema.optionalWith(NullableNumber, { default: () => null }),
@@ -175,11 +208,22 @@ const StateSchema = Schema.Struct({
   goals: Schema.Record({ key: Schema.String, value: GoalSchema }),
 })
 
-export type GoalSnapshot = Omit<Goal, "lastAccountedAt" | "autoTurns" | "lastContinuationAt"> & {
+// The public snapshot omits internal transport-recovery fields. The internal
+// continuation machinery (server and tests) reads them through
+// getGoalInternal / the internal snapshot type instead.
+export type GoalSnapshot = Omit<
+  Goal,
+  "lastAccountedAt" | "autoTurns" | "lastContinuationAt" | "pendingAttempt"
+> & {
   remainingTokens: number | null
   sampledAt: number
   autoTurns: number
   lastContinuationAt: number | null
+}
+
+/** Internal view of a goal with the pending-attempt lifecycle exposed. */
+export type InternalGoalSnapshot = GoalSnapshot & {
+  pendingAttempt: PendingAttempt | null
 }
 
 function defaultStateFile() {
@@ -321,11 +365,7 @@ function normalizeGoal(goal: Goal) {
     typeof goal.lastContinuationAt === "number" && Number.isFinite(goal.lastContinuationAt)
       ? Math.floor(goal.lastContinuationAt >= 1_000_000_000_000 ? goal.lastContinuationAt / 1000 : goal.lastContinuationAt)
       : null
-  goal.pendingContinuationStart =
-    typeof goal.pendingContinuationStart === "number" && Number.isFinite(goal.pendingContinuationStart)
-      ? goal.pendingContinuationStart
-      : null
-  goal.pendingContinuationStarted = goal.pendingContinuationStarted === true
+  goal.pendingAttempt = normalizePendingAttempt(goal.pendingAttempt)
   goal.continuationBaselineMessageID ??= ""
   goal.continuationBaselineSummary ??= ""
   goal.noProgressTurns = nonNegativeInteger(goal.noProgressTurns, 0)
@@ -337,6 +377,27 @@ function normalizeGoal(goal: Goal) {
   goal.budgetWrapupSent = goal.budgetWrapupSent === true
   goal.stopReason ??= null
   return goal
+}
+
+function normalizePendingAttempt(attempt: PendingAttempt | null | undefined): PendingAttempt | null {
+  if (!attempt || typeof attempt !== "object") return null
+  return {
+    id: typeof attempt.id === "string" && attempt.id ? attempt.id : randomId(),
+    reservedAt:
+      typeof attempt.reservedAt === "number" && Number.isFinite(attempt.reservedAt) ? attempt.reservedAt : Date.now(),
+    started: attempt.started === true,
+    delivered: attempt.delivered === true,
+    committed: attempt.committed === true,
+    armNoProgress: attempt.armNoProgress !== false,
+    previousLastContinuationAt:
+      typeof attempt.previousLastContinuationAt === "number" && Number.isFinite(attempt.previousLastContinuationAt)
+        ? attempt.previousLastContinuationAt
+        : null,
+  }
+}
+
+function randomId() {
+  return `att_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
 }
 
 function normalizeCreateOptions(input?: number | null | CreateGoalOptions): Required<CreateGoalOptions> {
@@ -401,8 +462,6 @@ export function snapshot(goal: Goal): GoalSnapshot {
     blocker: goal.blocker ?? null,
     closedAt: goal.closedAt ?? null,
     continuationFailures: goal.continuationFailures,
-    pendingContinuationStart: goal.pendingContinuationStart,
-    pendingContinuationStarted: goal.pendingContinuationStarted,
     lastStatus: goal.lastStatus,
     maxAutoTurns: goal.maxAutoTurns,
     maxDurationSeconds: goal.maxDurationSeconds,
@@ -427,10 +486,20 @@ export function snapshot(goal: Goal): GoalSnapshot {
   }
 }
 
+export function snapshotInternal(goal: Goal): InternalGoalSnapshot {
+  return { ...snapshot(goal), pendingAttempt: goal.pendingAttempt }
+}
+
 export async function getGoal(sessionID: string) {
   const state = await readState()
   const goal = state.goals[sessionID]
   return goal ? snapshot(goal) : null
+}
+
+export async function getGoalInternal(sessionID: string) {
+  const state = await readState()
+  const goal = state.goals[sessionID]
+  return goal ? snapshotInternal(goal) : null
 }
 
 export function getGoalSync(sessionID: string) {
@@ -465,8 +534,7 @@ export async function createGoal(sessionID: string, objective: string, options?:
       autoTurns: 0,
       lastContinuationAt: null,
       continuationFailures: 0,
-      pendingContinuationStart: null,
-      pendingContinuationStarted: false,
+      pendingAttempt: null,
       lastStatus: paused ? "Goal recorded from Plan mode; execution paused until resumed from Build mode." : "Goal set.",
       maxAutoTurns: normalizedOptions.maxAutoTurns,
       maxDurationSeconds: normalizedOptions.maxDurationSeconds,
@@ -516,8 +584,7 @@ export async function updateGoalObjective(
     goal.budgetWrapupSent = false
     if (goal.status === "active") {
       goal.continuationFailures = 0
-      goal.pendingContinuationStart = null
-      goal.pendingContinuationStarted = false
+      goal.pendingAttempt = null
       goal.awaitingContinuationProgress = false
     }
     if (agent) goal.lastPromptAgent = agent
@@ -571,8 +638,7 @@ export async function setGoalStatus(sessionID: string, status: MutableGoalStatus
     goal.updatedAt = nowSeconds()
     goal.lastAccountedAt = status === "active" ? goal.updatedAt : null
     goal.continuationFailures = status === "active" ? 0 : goal.continuationFailures
-    goal.pendingContinuationStart = status === "active" ? null : goal.pendingContinuationStart
-    goal.pendingContinuationStarted = status === "active" ? false : goal.pendingContinuationStarted
+    goal.pendingAttempt = status === "active" ? null : goal.pendingAttempt
     goal.noProgressTurns = status === "active" ? 0 : goal.noProgressTurns
     goal.stopReason = status === "active" ? null : "paused"
     goal.budgetWrapupSent = status === "active" ? false : goal.budgetWrapupSent
@@ -675,24 +741,33 @@ export async function recordAssistantProgress(sessionID: string, input: Assistan
     // so a pending continuation is resolved and any accumulated prompt failures
     // are cleared. Delivery of a prompt alone never resets the counter.
     if (substantive && summary && (!repeatedMessage || changed)) {
-      goal.continuationFailures = 0
-      goal.pendingContinuationStart = null
-      goal.pendingContinuationStarted = false
+      // Correlate the progress to the current attempt: delayed output that
+      // completed before this attempt was reserved belongs to a prior turn and
+      // must not clear a newer pending attempt. Guarded by the attempt's
+      // reservedAt anchor (ms). Without a timestamp we resolve conservatively.
+      const attempt = goal.pendingAttempt
+      if (attempt == null || input.completedAt == null || input.completedAt >= attempt.reservedAt) {
+        goal.continuationFailures = 0
+        goal.pendingAttempt = null
+      }
     }
 
     // No-progress accounting is scoped to goal continuation turns: it only runs
     // once per reserved continuation, when the completed turn is observed at the
     // next idle. Generic observation paths (messages.transform, message.updated)
     // record checkpoints above but never touch the counter.
+    const attemptForCompletion = goal.pendingAttempt
     const continuationTurnCompleted =
       input.evaluateContinuation === true &&
       goal.awaitingContinuationProgress &&
       Boolean(messageID) &&
-      messageID !== goal.continuationBaselineMessageID
+      messageID !== goal.continuationBaselineMessageID &&
+      // The turn must belong to (complete at/after) the current attempt; a
+      // delayed prior-turn message must not consume the evaluation.
+      (input.completedAt == null || attemptForCompletion == null || input.completedAt >= attemptForCompletion.reservedAt)
     if (continuationTurnCompleted) {
       goal.awaitingContinuationProgress = false
-      goal.pendingContinuationStart = null
-      goal.pendingContinuationStarted = false
+      goal.pendingAttempt = null
       const lowOutput = outputTokens > 0 && outputTokens < (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD)
       const changedSinceContinuation = Boolean(summary && summary !== goal.continuationBaselineSummary)
       if (lowOutput && !changedSinceContinuation) {
@@ -719,6 +794,13 @@ export async function recordAssistantProgress(sessionID: string, input: Assistan
   })
 }
 
+/**
+ * Persist the next automatic continuation attempt BEFORE the prompt is
+ * delivered so that a racing session.status "busy" can correlate to this exact
+ * attempt. The autoTurn and lastContinuationAt are committed immediately here
+ * (the attempt is a reserved turn); if the attempt is later canceled before it
+ * is actually sent, callers must roll it back with rollbackContinuationAttempt.
+ */
 export async function reserveContinuation(sessionID: string, maxAutoTurns: number, minIntervalSeconds: number) {
   return mutate((state) => {
     const goal = state.goals[sessionID]
@@ -730,16 +812,53 @@ export async function reserveContinuation(sessionID: string, maxAutoTurns: numbe
     if (maybeStopForUsageLimit(goal, maxAutoTurns, now)) return reserveWrapup(goal)
     if (goal.lastContinuationAt && now - goal.lastContinuationAt < minIntervalSeconds) return null
     goal.autoTurns += 1
+    const previousLastContinuationAt = goal.lastContinuationAt
     goal.lastContinuationAt = now
     // The baseline is captured at reservation time, but the no-progress
     // evaluation is only armed once recordContinuationResult confirms the
     // continuation prompt was actually delivered.
     goal.continuationBaselineMessageID = goal.lastAssistantMessageID
     goal.continuationBaselineSummary = summarizeText(goal.lastAssistantText)
+    goal.pendingAttempt = {
+      id: randomId(),
+      reservedAt: Date.now(),
+      started: false,
+      delivered: false,
+      committed: true,
+      armNoProgress: true,
+      previousLastContinuationAt,
+    }
+    goal.awaitingContinuationProgress = false
     goal.lastStatus = `Auto-continue ${goal.autoTurns} reserved.`
     pushHistory(goal, "autoContinue", goal.lastStatus)
     goal.updatedAt = now
-    return snapshot(goal)
+    return snapshotInternal(goal)
+  })
+}
+
+/**
+ * Roll back a reserved-but-not-delivered attempt: it must not consume an
+ * autoTurn or lastContinuationAt because it was canceled before the prompt was
+ * actually sent (e.g. a native retry, a dispose, or a plan/task deferral that
+ * short-circuited before delivery). Returns true if a committed attempt was
+ * rolled back.
+ */
+export async function rollbackContinuationAttempt(sessionID: string) {
+  return mutate((state) => {
+    const goal = state.goals[sessionID]
+    if (!goal) return false
+    const attempt = goal.pendingAttempt
+    if (!attempt || attempt.delivered || !attempt.committed) {
+      if (attempt && !attempt.delivered) goal.pendingAttempt = null
+      return false
+    }
+    goal.autoTurns = Math.max(0, goal.autoTurns - 1)
+    goal.lastContinuationAt = attempt.previousLastContinuationAt
+    goal.pendingAttempt = null
+    goal.awaitingContinuationProgress = false
+    goal.lastStatus = "Auto-continue attempt canceled before delivery."
+    goal.updatedAt = nowSeconds()
+    return true
   })
 }
 
@@ -751,29 +870,50 @@ export async function recordContinuationResult(
 ) {
   return mutate((state) => {
     const goal = state.goals[sessionID]
-    if (!goal || isClosed(goal.status)) return goal ? snapshot(goal) : null
+    if (!goal || isClosed(goal.status)) return goal ? snapshotInternal(goal) : null
     const now = nowSeconds()
     goal.updatedAt = now
     if (result === "success") {
-      // Successful prompt delivery arms the pending-continuation window but
-      // never resets the failure counter; only real progress, a successful
-      // tool output, or an explicit resume/new goal clears it. Delivery alone
-      // is not "started": a session.status busy event marks the attempt as
-      // actually started through markPendingContinuationStarted. Watchdog
-      // rescues deliver while already busy and pass started: true.
+      // Successful delivery commits the reserved attempt (it was armed before
+      // delivery so a racing busy already correlated to it). Delivery alone is
+      // not "started": a session.status busy event marks it started through
+      // markPendingContinuationStarted. Watchdog rescues deliver while already
+      // busy and pass started: true.
       if (goal.status === "active") {
-        goal.pendingContinuationStart = Date.now()
-        goal.pendingContinuationStarted = options?.started === true
+        const attempt = goal.pendingAttempt
+        if (attempt) {
+          attempt.delivered = true
+          // Preserve a started flag set by a busy that raced the delivery.
+          attempt.started = attempt.started || options?.started === true
+          attempt.armNoProgress = options?.armNoProgress ?? attempt.armNoProgress
+          if (attempt.armNoProgress) goal.awaitingContinuationProgress = true
+        } else {
+          // No reserved attempt (a watchdog rescue or a direct success call):
+          // arm a delivered untracked attempt so the pending window still
+          // works. It consumed no autoTurn (committed: false), so rollback
+          // treats it as unconsumed.
+          goal.pendingAttempt = {
+            id: randomId(),
+            reservedAt: Date.now(),
+            started: options?.started === true,
+            delivered: true,
+            committed: false,
+            armNoProgress: options?.armNoProgress !== false,
+            previousLastContinuationAt: goal.lastContinuationAt,
+          }
+          if (goal.pendingAttempt.armNoProgress) goal.awaitingContinuationProgress = true
+        }
         goal.lastStatus = "Auto-continue prompt sent."
-        if (options?.armNoProgress !== false) goal.awaitingContinuationProgress = true
       }
-      return snapshot(goal)
+      return snapshotInternal(goal)
     }
-    if (options?.requirePending && goal.pendingContinuationStart == null) return null
+    // Failure: only transport / unresolved no-response attempts count toward the
+    // ceiling. requirePending ensures a failure without a pending attempt (e.g.
+    // a stray duplicate transport event) is not double-counted.
+    if (options?.requirePending && goal.pendingAttempt == null) return null
     goal.continuationFailures += 1
     goal.awaitingContinuationProgress = false
-    goal.pendingContinuationStart = null
-    goal.pendingContinuationStarted = false
+    goal.pendingAttempt = null
     goal.lastStatus = `Auto-continue failed ${goal.continuationFailures} time(s).`
     pushHistory(goal, "error", goal.lastStatus)
     if (goal.continuationFailures >= maxFailures) {
@@ -785,47 +925,69 @@ export async function recordContinuationResult(
       goal.blocker = "Auto-continue prompt failed repeatedly. Resume the goal to retry."
       pushHistory(goal, "paused", goal.lastStatus)
     }
-    return snapshot(goal)
+    return snapshotInternal(goal)
   })
 }
 
 export async function markPendingContinuationStarted(sessionID: string) {
+  // Fast-path read: only a busy event for an active goal with an unstarted
+  // pending attempt warrants a state write. Goal-less or already-started busy
+  // events must not create or rewrite the state file.
+  const state = await readState()
+  const current = state.goals[sessionID]
+  if (!current || current.status !== "active") return current ? snapshotInternal(current) : null
+  if (current.pendingAttempt == null || current.pendingAttempt.started) return snapshotInternal(current)
   return mutate((state) => {
     const goal = state.goals[sessionID]
-    if (!goal || goal.status !== "active") return goal ? snapshot(goal) : null
-    if (goal.pendingContinuationStart == null || goal.pendingContinuationStarted) return snapshot(goal)
-    goal.pendingContinuationStarted = true
+    if (!goal || goal.status !== "active") return goal ? snapshotInternal(goal) : null
+    if (goal.pendingAttempt == null || goal.pendingAttempt.started) return snapshotInternal(goal)
+    goal.pendingAttempt.started = true
     goal.updatedAt = nowSeconds()
-    return snapshot(goal)
+    return snapshotInternal(goal)
   })
 }
 
-export async function recordToolProgress(sessionID: string, text?: string) {
+/**
+ * Record successful tool output as progress. The optional `expectedAttemptID`
+ * is the pending-attempt id captured when the tool call started: when it is
+ * provided (a string, or `null` when no attempt was pending then), a currently
+ * pending attempt is only cleared when it matches, so delayed output from an
+ * earlier turn can never clear a newer pending attempt. Omitting the argument
+ * keeps the legacy unconditional reset for direct callers.
+ */
+export async function recordToolProgress(sessionID: string, text?: string, expectedAttemptID?: string | null) {
   return mutate((state) => {
     const goal = state.goals[sessionID]
-    if (!goal || goal.status !== "active") return goal ? snapshot(goal) : null
+    if (!goal || goal.status !== "active") return goal ? snapshotInternal(goal) : null
     const value = text?.trim() ?? ""
-    if (!value) return snapshot(goal)
-    if (goal.continuationFailures === 0 && goal.pendingContinuationStart == null) return snapshot(goal)
-    // A successful tool output is real progress: it resolves any pending
-    // continuation and clears the prompt-failure counter. Failed tool outputs
-    // never reach this reset.
+    if (!value) return snapshotInternal(goal)
+    if (goal.continuationFailures === 0 && goal.pendingAttempt == null) return snapshotInternal(goal)
+    // A tool call that started before the current attempt was reserved may
+    // finish while a newer attempt is pending. Its output belongs to the prior
+    // turn, so it must not clear the newer attempt: only clear when the
+    // captured attempt matches, or when nothing is pending to protect.
+    if (goal.pendingAttempt != null && expectedAttemptID !== undefined && expectedAttemptID !== goal.pendingAttempt.id) {
+      return snapshotInternal(goal)
+    }
+    // A successful tool output is real progress for the transport: it resolves
+    // any pending continuation and clears the prompt-failure counter. It MUST
+    // NOT touch the continuation no-progress evaluation (awaitingContinuationProgress
+    // and noProgressTurns): a tool call that runs during a continuation turn
+    // must not reset the low-output accounting that the assistant's final text
+    // still needs to drive. Failed tool outputs never reach this reset.
     goal.continuationFailures = 0
-    goal.pendingContinuationStart = null
-    goal.pendingContinuationStarted = false
-    goal.awaitingContinuationProgress = false
-    goal.noProgressTurns = 0
+    goal.pendingAttempt = null
     goal.updatedAt = nowSeconds()
-    return snapshot(goal)
+    return snapshotInternal(goal)
   })
 }
 
-function reserveWrapup(goal: Goal) {
+function reserveWrapup(goal: Goal): InternalGoalSnapshot | null {
   if (goal.budgetWrapupSent) return null
   goal.budgetWrapupSent = true
   goal.updatedAt = nowSeconds()
   pushHistory(goal, "limited", `${goal.status}: ${goal.stopReason ?? "goal limit reached"}; requested final handoff.`)
-  return snapshot(goal)
+  return snapshotInternal(goal)
 }
 
 function maybeStopForBudget(goal: Goal) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -65,6 +65,8 @@ export type Goal = {
   autoTurns: number
   lastContinuationAt: number | null
   continuationFailures: number
+  pendingContinuationStart: number | null
+  pendingContinuationStarted: boolean
   lastStatus: string | null
   maxAutoTurns: number | null
   maxDurationSeconds: number | null
@@ -148,6 +150,8 @@ const GoalSchema = Schema.Struct({
   autoTurns: Schema.Number,
   lastContinuationAt: NullableNumber,
   continuationFailures: Schema.optionalWith(Schema.Number, { default: () => 0 }),
+  pendingContinuationStart: Schema.optionalWith(NullableNumber, { default: () => null }),
+  pendingContinuationStarted: Schema.optionalWith(Schema.Boolean, { default: () => false }),
   lastStatus: Schema.optionalWith(NullableString, { default: () => null }),
   maxAutoTurns: Schema.optionalWith(NullableNumber, { default: () => null }),
   maxDurationSeconds: Schema.optionalWith(NullableNumber, { default: () => null }),
@@ -313,6 +317,15 @@ function normalizeGoal(goal: Goal) {
   goal.lastAssistantMessageID ??= ""
   goal.lastPromptAgent ??= null
   goal.awaitingContinuationProgress = goal.awaitingContinuationProgress === true
+  goal.lastContinuationAt =
+    typeof goal.lastContinuationAt === "number" && Number.isFinite(goal.lastContinuationAt)
+      ? Math.floor(goal.lastContinuationAt >= 1_000_000_000_000 ? goal.lastContinuationAt / 1000 : goal.lastContinuationAt)
+      : null
+  goal.pendingContinuationStart =
+    typeof goal.pendingContinuationStart === "number" && Number.isFinite(goal.pendingContinuationStart)
+      ? goal.pendingContinuationStart
+      : null
+  goal.pendingContinuationStarted = goal.pendingContinuationStarted === true
   goal.continuationBaselineMessageID ??= ""
   goal.continuationBaselineSummary ??= ""
   goal.noProgressTurns = nonNegativeInteger(goal.noProgressTurns, 0)
@@ -388,6 +401,8 @@ export function snapshot(goal: Goal): GoalSnapshot {
     blocker: goal.blocker ?? null,
     closedAt: goal.closedAt ?? null,
     continuationFailures: goal.continuationFailures,
+    pendingContinuationStart: goal.pendingContinuationStart,
+    pendingContinuationStarted: goal.pendingContinuationStarted,
     lastStatus: goal.lastStatus,
     maxAutoTurns: goal.maxAutoTurns,
     maxDurationSeconds: goal.maxDurationSeconds,
@@ -450,6 +465,8 @@ export async function createGoal(sessionID: string, objective: string, options?:
       autoTurns: 0,
       lastContinuationAt: null,
       continuationFailures: 0,
+      pendingContinuationStart: null,
+      pendingContinuationStarted: false,
       lastStatus: paused ? "Goal recorded from Plan mode; execution paused until resumed from Build mode." : "Goal set.",
       maxAutoTurns: normalizedOptions.maxAutoTurns,
       maxDurationSeconds: normalizedOptions.maxDurationSeconds,
@@ -497,6 +514,12 @@ export async function updateGoalObjective(
     goal.closedAt = null
     goal.stopReason = planModePause ? PLAN_MODE_STOP_REASON : null
     goal.budgetWrapupSent = false
+    if (goal.status === "active") {
+      goal.continuationFailures = 0
+      goal.pendingContinuationStart = null
+      goal.pendingContinuationStarted = false
+      goal.awaitingContinuationProgress = false
+    }
     if (agent) goal.lastPromptAgent = agent
     goal.lastStatus = planModePause
       ? "Goal objective updated; execution paused while the session is in Plan mode."
@@ -548,6 +571,8 @@ export async function setGoalStatus(sessionID: string, status: MutableGoalStatus
     goal.updatedAt = nowSeconds()
     goal.lastAccountedAt = status === "active" ? goal.updatedAt : null
     goal.continuationFailures = status === "active" ? 0 : goal.continuationFailures
+    goal.pendingContinuationStart = status === "active" ? null : goal.pendingContinuationStart
+    goal.pendingContinuationStarted = status === "active" ? false : goal.pendingContinuationStarted
     goal.noProgressTurns = status === "active" ? 0 : goal.noProgressTurns
     goal.stopReason = status === "active" ? null : "paused"
     goal.budgetWrapupSent = status === "active" ? false : goal.budgetWrapupSent
@@ -637,6 +662,7 @@ export async function recordAssistantProgress(sessionID: string, input: Assistan
     const threshold = positiveIntegerOrNull(input.noProgressTokenThreshold) ?? goal.noProgressTokenThreshold
     const maxNoProgressTurns = positiveIntegerOrNull(input.maxNoProgressTurns) ?? goal.maxNoProgressTurns
     const summary = summarizeText(text)
+    const substantive = /[\p{L}\p{N}]/u.test(text)
     const previousSummary = summarizeText(goal.lastAssistantText)
     const repeatedMessage = Boolean(messageID && messageID === goal.lastAssistantMessageID)
     const changed = Boolean(summary && summary !== previousSummary)
@@ -644,6 +670,15 @@ export async function recordAssistantProgress(sessionID: string, input: Assistan
     if (summary && (!repeatedMessage || changed)) recordCheckpoint(goal, summary)
     if (text) goal.lastAssistantText = text
     if (messageID) goal.lastAssistantMessageID = messageID
+
+    // Substantive assistant text proves the continuation transport is healthy,
+    // so a pending continuation is resolved and any accumulated prompt failures
+    // are cleared. Delivery of a prompt alone never resets the counter.
+    if (substantive && summary && (!repeatedMessage || changed)) {
+      goal.continuationFailures = 0
+      goal.pendingContinuationStart = null
+      goal.pendingContinuationStarted = false
+    }
 
     // No-progress accounting is scoped to goal continuation turns: it only runs
     // once per reserved continuation, when the completed turn is observed at the
@@ -656,6 +691,8 @@ export async function recordAssistantProgress(sessionID: string, input: Assistan
       messageID !== goal.continuationBaselineMessageID
     if (continuationTurnCompleted) {
       goal.awaitingContinuationProgress = false
+      goal.pendingContinuationStart = null
+      goal.pendingContinuationStarted = false
       const lowOutput = outputTokens > 0 && outputTokens < (threshold ?? DEFAULT_NO_PROGRESS_TOKEN_THRESHOLD)
       const changedSinceContinuation = Boolean(summary && summary !== goal.continuationBaselineSummary)
       if (lowOutput && !changedSinceContinuation) {
@@ -706,22 +743,37 @@ export async function reserveContinuation(sessionID: string, maxAutoTurns: numbe
   })
 }
 
-export async function recordContinuationResult(sessionID: string, result: "success" | "failure", maxFailures: number) {
+export async function recordContinuationResult(
+  sessionID: string,
+  result: "success" | "failure",
+  maxFailures: number,
+  options?: { armNoProgress?: boolean; started?: boolean; requirePending?: boolean },
+) {
   return mutate((state) => {
     const goal = state.goals[sessionID]
     if (!goal || isClosed(goal.status)) return goal ? snapshot(goal) : null
     const now = nowSeconds()
     goal.updatedAt = now
     if (result === "success") {
-      goal.continuationFailures = 0
+      // Successful prompt delivery arms the pending-continuation window but
+      // never resets the failure counter; only real progress, a successful
+      // tool output, or an explicit resume/new goal clears it. Delivery alone
+      // is not "started": a session.status busy event marks the attempt as
+      // actually started through markPendingContinuationStarted. Watchdog
+      // rescues deliver while already busy and pass started: true.
       if (goal.status === "active") {
+        goal.pendingContinuationStart = Date.now()
+        goal.pendingContinuationStarted = options?.started === true
         goal.lastStatus = "Auto-continue prompt sent."
-        goal.awaitingContinuationProgress = true
+        if (options?.armNoProgress !== false) goal.awaitingContinuationProgress = true
       }
       return snapshot(goal)
     }
+    if (options?.requirePending && goal.pendingContinuationStart == null) return null
     goal.continuationFailures += 1
     goal.awaitingContinuationProgress = false
+    goal.pendingContinuationStart = null
+    goal.pendingContinuationStarted = false
     goal.lastStatus = `Auto-continue failed ${goal.continuationFailures} time(s).`
     pushHistory(goal, "error", goal.lastStatus)
     if (goal.continuationFailures >= maxFailures) {
@@ -733,6 +785,37 @@ export async function recordContinuationResult(sessionID: string, result: "succe
       goal.blocker = "Auto-continue prompt failed repeatedly. Resume the goal to retry."
       pushHistory(goal, "paused", goal.lastStatus)
     }
+    return snapshot(goal)
+  })
+}
+
+export async function markPendingContinuationStarted(sessionID: string) {
+  return mutate((state) => {
+    const goal = state.goals[sessionID]
+    if (!goal || goal.status !== "active") return goal ? snapshot(goal) : null
+    if (goal.pendingContinuationStart == null || goal.pendingContinuationStarted) return snapshot(goal)
+    goal.pendingContinuationStarted = true
+    goal.updatedAt = nowSeconds()
+    return snapshot(goal)
+  })
+}
+
+export async function recordToolProgress(sessionID: string, text?: string) {
+  return mutate((state) => {
+    const goal = state.goals[sessionID]
+    if (!goal || goal.status !== "active") return goal ? snapshot(goal) : null
+    const value = text?.trim() ?? ""
+    if (!value) return snapshot(goal)
+    if (goal.continuationFailures === 0 && goal.pendingContinuationStart == null) return snapshot(goal)
+    // A successful tool output is real progress: it resolves any pending
+    // continuation and clears the prompt-failure counter. Failed tool outputs
+    // never reach this reset.
+    goal.continuationFailures = 0
+    goal.pendingContinuationStart = null
+    goal.pendingContinuationStarted = false
+    goal.awaitingContinuationProgress = false
+    goal.noProgressTurns = 0
+    goal.updatedAt = nowSeconds()
     return snapshot(goal)
   })
 }

--- a/test/server-v2.test.ts
+++ b/test/server-v2.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import plugin from "../src/server"
-import { getGoal } from "../src/state"
+import { getGoal, getGoalInternal, recordContinuationResult, reserveContinuation } from "../src/state"
 
 const TOOL_NAMES = [
   "clear_goal",
@@ -453,4 +453,419 @@ test("V2 cleanup disposes registrations and stops the event consumer", async () 
   await new Promise((resolve) => setTimeout(resolve, 30))
   const read = await goalTool(mock, "get_goal").execute({}, toolContext())
   expect(contentOf(read)).toContain('"tokensUsed": 0')
+})
+
+test("V2 session.error schedules bounded recovery without a phantom failure", async () => {
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0, max_auto_turns: 5 })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "recover from a transport error")
+
+  mock.stream.push({
+    type: "session.error",
+    created: Date.now(),
+    data: { sessionID: "ses_v2", error: { message: "network connection failed" } },
+  })
+  await waitFor(() => mock.promptCalls.length === 1)
+
+  const goal = await getGoal("ses_v2")
+  expect(goal?.continuationFailures).toBe(0)
+  expect(goal?.autoTurns).toBe(1)
+  expect(goal?.status).toBe("active")
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 idle after a started pending attempt counts one unresolved failure and pauses at the ceiling", async () => {
+  const mock = makeMockContext({
+    auto_continue: true,
+    min_continue_interval_seconds: 0,
+    max_auto_turns: 5,
+    max_prompt_failures: 1,
+  })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "detect a no response")
+
+  mock.stream.push({ type: "session.idle", created: 1, data: { sessionID: "ses_v2" } })
+  await waitFor(() => mock.promptCalls.length === 1)
+  mock.stream.push({ type: "session.status", created: 2, data: { sessionID: "ses_v2", status: { type: "busy" } } })
+
+  // The provider picks up the prompt: the busy marks the persisted attempt started.
+  await waitFor(async () => (await getGoalInternal("ses_v2"))?.pendingAttempt?.started === true)
+  expect((await getGoalInternal("ses_v2"))?.pendingAttempt?.started).toBe(true)
+
+  // The following idle has no assistant output: exactly one unresolved failure.
+  mock.stream.push({ type: "session.idle", created: 3, data: { sessionID: "ses_v2" } })
+  await waitFor(async () => (await getGoal("ses_v2"))?.status === "paused")
+  expect((await getGoal("ses_v2"))?.continuationFailures).toBe(1)
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 persists the attempt before the prompt resolves so a later busy can correlate", async () => {
+  let resolvePrompt: (() => void) | undefined
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 3 })
+  mock.session.prompt = async (input: { sessionID: string; text: string }) => {
+    mock.promptCalls.push(input)
+    await new Promise<void>((resolve) => {
+      resolvePrompt = resolve
+    })
+  }
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "correlate a racing busy")
+
+  void mock.stream.push({ type: "session.idle", created: 1, data: { sessionID: "ses_v2" } })
+  await waitFor(() => mock.promptCalls.length === 1)
+
+  // The attempt is persisted BEFORE the prompt resolves, so a provider busy
+  // (whenever it arrives) correlates to this exact attempt rather than a
+  // local-only timing assumption.
+  const during = await getGoalInternal("ses_v2")
+  expect(during?.pendingAttempt).not.toBeNull()
+  expect(during?.pendingAttempt?.delivered).toBe(false)
+
+  resolvePrompt?.()
+  await waitFor(async () => (await getGoalInternal("ses_v2"))?.pendingAttempt?.delivered === true)
+
+  // A busy arriving after delivery still marks the same persisted attempt.
+  mock.stream.push({ type: "session.status", created: 2, data: { sessionID: "ses_v2", status: { type: "busy" } } })
+  await waitFor(async () => (await getGoalInternal("ses_v2"))?.pendingAttempt?.started === true)
+  expect((await getGoalInternal("ses_v2"))?.pendingAttempt?.started).toBe(true)
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 retry status cancels scheduled transport recovery", async () => {
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0 })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "let the native retry win")
+
+  mock.stream.push({
+    type: "session.error",
+    created: 1,
+    data: { sessionID: "ses_v2", error: { message: "network connection failed" } },
+  })
+  mock.stream.push({ type: "session.status", created: 2, data: { sessionID: "ses_v2", status: { type: "retry" } } })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(mock.promptCalls).toHaveLength(0)
+  expect((await getGoal("ses_v2"))?.continuationFailures).toBe(0)
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 successful tool progress cancels no-pending transport recovery", async () => {
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0 })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "cancel recovery via tool progress")
+
+  mock.stream.push({
+    type: "session.error",
+    created: 1,
+    data: { sessionID: "ses_v2", error: { message: "network connection failed" } },
+  })
+  // Drain the FIFO event stream deterministically: a later usage event writes
+  // state, so once it is visible the transport error above has already been
+  // processed and its recovery timer scheduled. Then cancel it via the awaited
+  // tool hook before the timer (RETRY_SETTLE_MS) can fire.
+  mock.stream.push({
+    type: "session.usage.updated",
+    created: 2,
+    data: { sessionID: "ses_v2", tokens: { input: 5, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+  })
+  await waitFor(async () => (await getGoal("ses_v2"))?.tokensUsed === 5)
+  await mock.hooks["execute.after"]!({
+    tool: "bash",
+    sessionID: "ses_v2",
+    id: "call_progress",
+    status: "completed",
+    result: { output: "tests passed" },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(mock.promptCalls).toHaveLength(0)
+  expect((await getGoal("ses_v2"))?.continuationFailures).toBe(0)
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 assistant progress cancels no-pending transport recovery", async () => {
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0 })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "cancel recovery via assistant progress")
+
+  mock.stream.push({
+    type: "session.error",
+    created: 1,
+    data: { sessionID: "ses_v2", error: { message: "network connection failed" } },
+  })
+  mock.stream.push({
+    type: "session.step.started",
+    created: 20,
+    data: { sessionID: "ses_v2", assistantMessageID: "msg_recovered", agent: "build" },
+  })
+  mock.stream.push({
+    type: "session.text.ended",
+    created: 21,
+    data: { sessionID: "ses_v2", assistantMessageID: "msg_recovered", text: "The provider recovered on its own." },
+  })
+  mock.stream.push({
+    type: "session.step.ended",
+    created: 22,
+    data: { sessionID: "ses_v2", assistantMessageID: "msg_recovered", tokens: { input: 10, output: 20, reasoning: 0, cache: { read: 0, write: 0 } } },
+  })
+  await waitFor(async () => (await getGoal("ses_v2"))?.lastAssistantMessageID === "msg_recovered")
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(mock.promptCalls).toHaveLength(0)
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 watchdog rescues a busy active goal without consuming auto-turn budgets", async () => {
+  const mock = makeMockContext({ auto_continue: false, max_turn_time: 0.02, max_prompt_failures: 5, max_auto_turns: 1 })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "watchdog should not eat the budget")
+
+  mock.stream.push({ type: "session.status", created: Date.now(), data: { sessionID: "ses_v2", status: { type: "busy" } } })
+  await waitFor(() => mock.promptCalls.length === 1)
+
+  expect(mock.promptCalls).toHaveLength(1)
+  expect((await getGoal("ses_v2"))?.autoTurns).toBe(0)
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 non-transport prompt errors do not count toward the ceiling or retry", async () => {
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 3 })
+  mock.session.prompt = async () => {
+    throw new Error("invalid provider configuration")
+  }
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "non-transport must be ignored")
+
+  mock.stream.push({ type: "session.idle", created: Date.now(), data: { sessionID: "ses_v2" } })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  const goal = await getGoal("ses_v2")
+  expect(goal?.continuationFailures).toBe(0)
+  expect(goal?.status).toBe("active")
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 a native retry status suppresses a later session.error until busy ends the episode", async () => {
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 3 })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "native retry must win")
+
+  // retry arrives before the transport error; the error is suppressed while
+  // the provider is already retrying.
+  mock.stream.push({ type: "session.status", created: 1, data: { sessionID: "ses_v2", status: { type: "retry" } } })
+  mock.stream.push({
+    type: "session.error",
+    created: 2,
+    data: { sessionID: "ses_v2", error: { message: "network connection failed" } },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(mock.promptCalls).toHaveLength(0)
+  const suppressed = await getGoal("ses_v2")
+  expect(suppressed?.continuationFailures).toBe(0)
+  expect(suppressed?.status).toBe("active")
+
+  // busy ends the retry episode; a later transport error may then recover.
+  mock.stream.push({ type: "session.status", created: 3, data: { sessionID: "ses_v2", status: { type: "busy" } } })
+  mock.stream.push({
+    type: "session.error",
+    created: 4,
+    data: { sessionID: "ses_v2", error: { message: "network connection failed" } },
+  })
+  await waitFor(() => mock.promptCalls.length === 1)
+  expect(mock.promptCalls[0]?.text).toContain("Continue working toward the active session goal")
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 watchdog no-response counts a failure on idle even with auto_continue false", async () => {
+  const mock = makeMockContext({ auto_continue: false, max_turn_time: 0.02, max_prompt_failures: 5, max_auto_turns: 1 })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "watchdog no response with auto-continue disabled")
+
+  mock.stream.push({ type: "session.status", created: Date.now(), data: { sessionID: "ses_v2", status: { type: "busy" } } })
+  await waitFor(async () => (await getGoalInternal("ses_v2"))?.pendingAttempt?.started === true)
+  await waitFor(() => mock.promptCalls.length === 1)
+  expect((await getGoal("ses_v2"))?.autoTurns).toBe(0)
+
+  // The busy episode ends with no response: the started pending attempt counts
+  // exactly one unresolved failure even though auto-continue is disabled, and
+  // no retry is scheduled.
+  mock.stream.push({ type: "session.idle", created: Date.now(), data: { sessionID: "ses_v2" } })
+  await waitFor(async () => (await getGoal("ses_v2"))?.continuationFailures === 1)
+
+  const goal = await getGoal("ses_v2")
+  expect(goal?.continuationFailures).toBe(1)
+  expect(goal?.autoTurns).toBe(0)
+  expect(goal?.status).toBe("active")
+  expect((await getGoalInternal("ses_v2"))?.pendingAttempt).toBeNull()
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  expect(mock.promptCalls).toHaveLength(1)
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 delayed tool output from a prior turn cannot clear a newer pending attempt", async () => {
+  const mock = makeMockContext({ auto_continue: false })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "correlate tool progress to the attempt")
+
+  // The tool call starts while attempt A is pending; the before hook captures
+  // the attempt id for the session+call key.
+  await reserveContinuation("ses_v2", 10, 0)
+  await recordContinuationResult("ses_v2", "success", 5)
+  const attemptA = (await getGoalInternal("ses_v2"))?.pendingAttempt?.id
+  expect(attemptA).toMatch(/^att_/)
+  await mock.hooks["execute.before"]!({ tool: "bash", sessionID: "ses_v2", id: "call_delayed", input: {} })
+
+  // A newer attempt B is reserved while the tool is still running.
+  await reserveContinuation("ses_v2", 10, 0)
+  await recordContinuationResult("ses_v2", "success", 5)
+  const attemptB = (await getGoalInternal("ses_v2"))?.pendingAttempt?.id
+  expect(attemptB).not.toBe(attemptA)
+
+  // The delayed output from the old call must leave attempt B pending.
+  await mock.hooks["execute.after"]!({
+    tool: "bash",
+    sessionID: "ses_v2",
+    id: "call_delayed",
+    status: "completed",
+    result: { output: "tests passed" },
+  })
+  expect((await getGoalInternal("ses_v2"))?.pendingAttempt?.id).toBe(attemptB)
+
+  // A tool call that started while attempt B was pending clears it.
+  await mock.hooks["execute.before"]!({ tool: "bash", sessionID: "ses_v2", id: "call_current", input: {} })
+  await mock.hooks["execute.after"]!({
+    tool: "bash",
+    sessionID: "ses_v2",
+    id: "call_current",
+    status: "completed",
+    result: { output: "more progress" },
+  })
+  expect((await getGoalInternal("ses_v2"))?.pendingAttempt).toBeNull()
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 dispose during an in-flight prompt rolls back the reserved attempt on rejection", async () => {
+  let resolvePrompt: (() => void) | undefined
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 3 })
+  mock.session.prompt = async (input: { sessionID: string; text: string }) => {
+    mock.promptCalls.push(input)
+    await new Promise<void>((resolve) => {
+      resolvePrompt = resolve
+    })
+    throw new Error("network down")
+  }
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "dispose mid-flight rejection")
+
+  void mock.stream.push({ type: "session.idle", created: 1, data: { sessionID: "ses_v2" } })
+  await waitFor(() => mock.promptCalls.length === 1)
+
+  // Dispose while the prompt is in flight, then let it fail: the catch block
+  // must roll back the reserved attempt without counting a transport failure
+  // or consuming an auto-turn.
+  await cleanup()
+  resolvePrompt?.()
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(mock.promptCalls).toHaveLength(1)
+  const goal = await getGoal("ses_v2")
+  expect(goal?.autoTurns).toBe(0)
+  expect(goal?.continuationFailures).toBe(0)
+  expect(goal?.status).toBe("active")
+  expect((await getGoalInternal("ses_v2"))?.pendingAttempt).toBeNull()
+})
+
+test("V2 commits an accepted prompt when its recovery timer is canceled in flight", async () => {
+  let resolvePrompt: (() => void) | undefined
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0 })
+  mock.session.prompt = async (input) => {
+    mock.promptCalls.push(input)
+    await new Promise<void>((resolve) => {
+      resolvePrompt = resolve
+    })
+  }
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "commit accepted recovery")
+
+  mock.stream.push({
+    type: "session.error",
+    created: Date.now(),
+    data: { sessionID: "ses_v2", error: { message: "network connection failed" } },
+  })
+  await waitFor(() => mock.promptCalls.length === 1)
+
+  // Concurrent progress cancels the timer while prompt() is still in flight.
+  // Once prompt() resolves, its accepted delivery must remain charged/tracked.
+  await mock.hooks["execute.before"]!({ tool: "bash", sessionID: "ses_v2", id: "call_cancel" })
+  await mock.hooks["execute.after"]!({
+    tool: "bash",
+    sessionID: "ses_v2",
+    id: "call_cancel",
+    status: "completed",
+    result: { output: "progress from the active session" },
+  })
+  resolvePrompt?.()
+
+  await waitFor(async () => (await getGoalInternal("ses_v2"))?.pendingAttempt?.delivered === true)
+  expect((await getGoal("ses_v2"))?.autoTurns).toBe(1)
+  expect(mock.promptCalls).toHaveLength(1)
+
+  mock.stream.end()
+  await cleanup()
+})
+
+test("V2 completed tool failures do not clear retry state", async () => {
+  const mock = makeMockContext({ auto_continue: false })
+  const cleanup = await plugin.setup(mock as never)
+  await createGoalViaV2Tool(mock, "keep failed tools from masking recovery")
+
+  await reserveContinuation("ses_v2", 10, 0)
+  await recordContinuationResult("ses_v2", "failure", 5)
+  await reserveContinuation("ses_v2", 10, 0)
+  await recordContinuationResult("ses_v2", "success", 5)
+  const attemptID = (await getGoalInternal("ses_v2"))?.pendingAttempt?.id
+  expect(attemptID).toBeTypeOf("string")
+
+  for (const [id, output] of [
+    ["call_running", "state: running\nstill working"],
+    ["call_error", "<error>command failed</error>"],
+  ] as const) {
+    await mock.hooks["execute.before"]!({ tool: "bash", sessionID: "ses_v2", id })
+    await mock.hooks["execute.after"]!({
+      tool: "bash",
+      sessionID: "ses_v2",
+      id,
+      status: "completed",
+      result: { output },
+    })
+    const goal = await getGoalInternal("ses_v2")
+    expect(goal?.continuationFailures).toBe(1)
+    expect(goal?.pendingAttempt?.id).toBe(attemptID)
+  }
+
+  mock.stream.end()
+  await cleanup()
 })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import plugin from "../src/server"
 import {
   getGoal,
+  getGoalInternal,
   recordContinuationResult,
   reserveContinuation,
 } from "../src/state"
@@ -668,7 +669,7 @@ test("turn watchdog retries a busy active goal without consuming continuation bu
   expect(String(read)).toContain('"awaitingContinuationProgress": false')
   // A watchdog-delivered prompt is already inside a busy episode, so the
   // pending attempt is marked started immediately.
-  expect(String(read)).toContain('"pendingContinuationStarted": true')
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt?.started).toBe(true)
 
   // The busy episode ends. Auto-continue is disabled here, so nothing further
   // happens on idle; the watchdog-delivered attempt stays pending and started.
@@ -677,7 +678,7 @@ test("turn watchdog retries a busy active goal without consuming continuation bu
   expect(String(afterIdle)).toContain('"status": "active"')
   expect(String(afterIdle)).toContain('"autoTurns": 0')
   expect(String(afterIdle)).toContain('"continuationFailures": 1')
-  expect(String(afterIdle)).toContain('"pendingContinuationStart": null')
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).toBeNull()
 
   // A new busy episode rescues again, still without auto-turn budgets.
   await hooks.event!({
@@ -732,23 +733,29 @@ test("turn watchdog cancels on idle, retry, deletion, and dispose", async () => 
         },
       },
     } as never,
-    { auto_continue: false, max_turn_time: 0.02 },
+    { auto_continue: false, max_turn_time: 0.08 },
   )
   const tools = hooks.tool
   if (!tools) throw new Error("expected goal tools to be registered")
 
   for (const sessionID of ["ses_idle", "ses_retry", "ses_deleted"]) {
     await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID } as never)
-    await hooks.event!({
-      event: { type: "session.status", properties: { sessionID, status: { type: "busy" } } } as never,
-    })
   }
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_idle", status: { type: "busy" } } } as never,
+  })
   await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_idle" } } as never })
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_retry", status: { type: "busy" } } } as never,
+  })
   await hooks.event!({
     event: { type: "session.status", properties: { sessionID: "ses_retry", status: { type: "retry" } } } as never,
   })
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_deleted", status: { type: "busy" } } } as never,
+  })
   await hooks.event!({ event: { type: "session.deleted", properties: { info: { id: "ses_deleted" } } } as never })
-  await new Promise((resolve) => setTimeout(resolve, 50))
+  await new Promise((resolve) => setTimeout(resolve, 100))
 
   expect(calls).toHaveLength(0)
 
@@ -760,7 +767,7 @@ test("turn watchdog cancels on idle, retry, deletion, and dispose", async () => 
     event: { type: "session.status", properties: { sessionID: "ses_disposed", status: { type: "busy" } } } as never,
   })
   await hooks.dispose?.()
-  await new Promise((resolve) => setTimeout(resolve, 50))
+  await new Promise((resolve) => setTimeout(resolve, 100))
 
   expect(calls).toHaveLength(0)
 })
@@ -1865,7 +1872,7 @@ test("failed tool output does not reset prompt failures; successful tool output 
   )
   const afterSuccessfulTool = await requireTool(tools.get_goal, "get_goal").execute({}, context)
   expect(String(afterSuccessfulTool)).toContain('"continuationFailures": 0')
-  expect(String(afterSuccessfulTool)).toContain('"pendingContinuationStart": null')
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).toBeNull()
 })
 
 test("duplicate idle events before any busy never count a failure or send a duplicate", async () => {
@@ -1899,8 +1906,10 @@ test("duplicate idle events before any busy never count a failure or send a dupl
   const read = await requireTool(tools.get_goal, "get_goal").execute({}, context)
   expect(String(read)).toContain('"status": "active"')
   expect(String(read)).toContain('"continuationFailures": 0')
-  expect(String(read)).toContain('"pendingContinuationStarted": false')
-  expect(String(read)).not.toContain('"pendingContinuationStart": null')
+  // The attempt was delivered but never started by a busy; it must remain
+  // pending until it either starts or goes stale.
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt?.started).toBe(false)
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).not.toBeNull()
 })
 
 test("paired idle events after a busy count exactly one unresolved failure and pause at the ceiling", async () => {
@@ -1929,8 +1938,7 @@ test("paired idle events after a busy count exactly one unresolved failure and p
   await hooks.event!({
     event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
   })
-  const started = await requireTool(tools.get_goal, "get_goal").execute({}, context)
-  expect(String(started)).toContain('"pendingContinuationStarted": true')
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt?.started).toBe(true)
 
   // The following logical idle has no substantive progress: exactly one
   // unresolved failure is counted, which hits the ceiling and pauses.
@@ -1967,7 +1975,7 @@ test("concurrent session.error transport events count at most one failure per pe
   await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
   await reserveContinuation("ses_1", 10, 0)
   await recordContinuationResult("ses_1", "success", 3)
-  expect((await getGoal("ses_1"))?.pendingContinuationStart).not.toBeNull()
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).not.toBeNull()
 
   const transportEvent = {
     event: {
@@ -2079,7 +2087,7 @@ test("a repeated old assistant message cannot hide a no-response failure", async
   expect(calls).toHaveLength(1)
 })
 
-test("non-transport prompt errors preserve failure accounting without automatic retry", async () => {
+test("non-transport prompt errors do not count toward the ceiling or auto-retry", async () => {
   const logs: unknown[] = []
   let calls = 0
   const hooks = await plugin.server(
@@ -2104,9 +2112,13 @@ test("non-transport prompt errors preserve failure accounting without automatic 
   await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_non_transport" } } as never })
   await new Promise((resolve) => setTimeout(resolve, 100))
 
+  // Non-transport failures are neither transport nor no-response: they must
+  // not increment the max_prompt_failures ceiling nor schedule an auto-retry,
+  // while preserving useful error logging.
   expect(calls).toBe(1)
   expect(logs).toHaveLength(1)
-  expect((await getGoal("ses_non_transport"))?.continuationFailures).toBe(1)
+  expect((await getGoal("ses_non_transport"))?.continuationFailures).toBe(0)
+  expect((await getGoal("ses_non_transport"))?.status).toBe("active")
 })
 
 test("session.error without a pending attempt schedules recovery without a phantom failure", async () => {
@@ -2222,14 +2234,21 @@ test("persisted started=false pending attempts go stale after restart", async ()
   await requireTool(tools1.create_goal, "create_goal").execute({ objective: "keep going" }, context)
   await reserveContinuation("ses_1", 10, 0)
   await recordContinuationResult("ses_1", "success", 5)
-  expect((await getGoal("ses_1"))?.pendingContinuationStarted).toBe(false)
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt?.started).toBe(false)
 
-  // Simulate an old persisted attempt by writing a stale millisecond timestamp
-  // directly into the state file instead of waiting 30 seconds.
+  // Simulate an old persisted attempt by writing a stale millisecond reservedAt
+  // timestamp directly into the state file instead of waiting 30 seconds.
   const file = process.env.OPENCODE_GOAL_STATE_PATH!
   const state = JSON.parse(await readFile(file, "utf8"))
-  state.goals.ses_1.pendingContinuationStart = Date.now() - 60_000
-  state.goals.ses_1.pendingContinuationStarted = false
+  state.goals.ses_1.pendingAttempt = {
+    id: "att_stale",
+    reservedAt: Date.now() - 60_000,
+    started: false,
+    delivered: true,
+    committed: true,
+    armNoProgress: true,
+    previousLastContinuationAt: null,
+  }
   await writeFile(file, JSON.stringify(state))
   await hooks1.dispose?.()
 
@@ -2282,7 +2301,15 @@ test("a locally delivered unstarted attempt never becomes a false no-response fa
 
   const file = process.env.OPENCODE_GOAL_STATE_PATH!
   const state = JSON.parse(await readFile(file, "utf8"))
-  state.goals.ses_local_pending.pendingContinuationStart = Date.now() - 60_000
+  state.goals.ses_local_pending.pendingAttempt = {
+    id: "att_local",
+    reservedAt: Date.now() - 60_000,
+    started: false,
+    delivered: true,
+    committed: true,
+    armNoProgress: true,
+    previousLastContinuationAt: null,
+  }
   await writeFile(file, JSON.stringify(state))
   await hooks.event!({
     event: { type: "session.status", properties: { sessionID: "ses_local_pending", status: { type: "idle" } } } as never,
@@ -2328,6 +2355,109 @@ test("a built-in retry status cancels scheduled transport recovery", async () =>
 
   expect(calls).toHaveLength(0)
   expect((await getGoal("ses_native_retry"))?.continuationFailures).toBe(0)
+})
+
+test("a native retry status suppresses a later session.error until busy or idle ends the episode", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const sessionID = "ses_retry_first"
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID } as never)
+
+  // The native retry status arrives BEFORE the transport error. The error must
+  // not schedule plugin recovery while the provider is already retrying.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID, status: { type: "retry" } } } as never,
+  })
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: { sessionID, error: { message: "network connection failed" } },
+    } as never,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(calls).toHaveLength(0)
+  expect((await getGoal(sessionID))?.continuationFailures).toBe(0)
+  expect((await getGoal(sessionID))?.status).toBe("active")
+
+  // busy ends the retry episode and clears the marker; a subsequent transport
+  // error outside the episode may then start plugin recovery.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID, status: { type: "busy" } } } as never,
+  })
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: { sessionID, error: { message: "network connection failed" } },
+    } as never,
+  })
+  await waitForLong(() => calls.length === 1)
+  expect(JSON.stringify(calls[0])).toContain("Continue working toward the active session goal")
+})
+
+test("an error during a native retry episode does not fail the pending attempt", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: false, min_continue_interval_seconds: 0, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const sessionID = "ses_retry_pending"
+  const context = { sessionID } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await reserveContinuation(sessionID, 10, 0)
+  await recordContinuationResult(sessionID, "success", 5)
+  const attemptId = (await getGoalInternal(sessionID))?.pendingAttempt?.id
+  expect(attemptId).toMatch(/^att_/)
+
+  // retry -> error while a prompt is pending: the suppressed error must not
+  // count a failure or clear the pending attempt.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID, status: { type: "retry" } } } as never,
+  })
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: { sessionID, error: { message: "network connection failed" } },
+    } as never,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(calls).toHaveLength(0)
+  expect((await getGoal(sessionID))?.continuationFailures).toBe(0)
+  expect((await getGoalInternal(sessionID))?.pendingAttempt?.id).toBe(attemptId)
+
+  // busy ends the retry episode and marks the attempt started; the following
+  // idle then counts exactly one unresolved failure.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID, status: { type: "busy" } } } as never,
+  })
+  expect((await getGoalInternal(sessionID))?.pendingAttempt?.started).toBe(true)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID } } as never })
+  expect((await getGoal(sessionID))?.continuationFailures).toBe(1)
+  expect((await getGoalInternal(sessionID))?.pendingAttempt).toBeNull()
 })
 
 test("assistant progress cancels no-pending transport recovery", async () => {
@@ -2492,6 +2622,59 @@ test("tool progress honors completed states and never resets on failed or incomp
   expect(String(plainSuccess)).toContain('"continuationFailures": 0')
 })
 
+test("delayed tool output from a prior turn cannot clear a newer pending attempt", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const sessionID = "ses_delayed_tool"
+  const context = { sessionID } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+
+  // The tool call starts while attempt A is pending; the before hook captures
+  // the attempt id for this session+call key.
+  await reserveContinuation(sessionID, 10, 0)
+  await recordContinuationResult(sessionID, "success", 5)
+  const attemptA = (await getGoalInternal(sessionID))?.pendingAttempt?.id
+  expect(attemptA).toMatch(/^att_/)
+  await hooks["tool.execute.before"]!(
+    { tool: "bash", sessionID, callID: "call_delayed", args: {} } as never,
+    {} as never,
+  )
+
+  // A newer attempt B is reserved while the tool is still running.
+  await reserveContinuation(sessionID, 10, 0)
+  await recordContinuationResult(sessionID, "success", 5)
+  const attemptB = (await getGoalInternal(sessionID))?.pendingAttempt?.id
+  expect(attemptB).not.toBe(attemptA)
+
+  // The delayed output from the old call must leave attempt B pending.
+  await hooks["tool.execute.after"]!(
+    { tool: "bash", sessionID, callID: "call_delayed", args: {} } as never,
+    { title: "bash", output: "tests passed", metadata: {} } as never,
+  )
+  expect((await getGoalInternal(sessionID))?.pendingAttempt?.id).toBe(attemptB)
+
+  // A tool call that started while attempt B was pending clears it.
+  await hooks["tool.execute.before"]!(
+    { tool: "bash", sessionID, callID: "call_current", args: {} } as never,
+    {} as never,
+  )
+  await hooks["tool.execute.after"]!(
+    { tool: "bash", sessionID, callID: "call_current", args: {} } as never,
+    { title: "bash", output: "more progress", metadata: {} } as never,
+  )
+  expect((await getGoalInternal(sessionID))?.pendingAttempt).toBeNull()
+})
+
 test("watchdog rescues at most once per busy episode", async () => {
   const calls: unknown[] = []
   const hooks = await plugin.server(
@@ -2531,4 +2714,159 @@ test("watchdog rescues at most once per busy episode", async () => {
   })
   await waitFor(() => calls.length === 2)
   expect(calls).toHaveLength(2)
+})
+
+test("a busy that races prompt resolution correlates to the persisted attempt", async () => {
+  let resolvePrompt: (() => void) | undefined
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+            await new Promise<void>((resolve) => {
+              resolvePrompt = resolve
+            })
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const context = { sessionID: "ses_busy_race" } as never
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  // Start auto-continue; the prompt stays in flight inside session.promptAsync.
+  // Fire-and-forget: the idle handler awaits runAutoContinue which blocks on
+  // the unresolved prompt, so we must not await it here.
+  void hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_busy_race" } } as never })
+  await waitFor(() => calls.length === 1)
+
+  // A busy arrives BEFORE promptAsync resolves. Because the attempt is
+  // persisted before delivery, the busy correlates to the correct attempt and
+  // marks it started even though delivery has not finished yet.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_busy_race", status: { type: "busy" } } } as never,
+  })
+  expect((await getGoalInternal("ses_busy_race"))?.pendingAttempt?.started).toBe(true)
+
+  // Delivery finishes; it must preserve the started flag set by the racing busy.
+  resolvePrompt?.()
+  await waitForLong(async () => (await getGoalInternal("ses_busy_race"))?.pendingAttempt?.delivered === true)
+  expect((await getGoalInternal("ses_busy_race"))?.pendingAttempt?.started).toBe(true)
+  expect(calls).toHaveLength(1)
+
+  await hooks.dispose?.()
+})
+
+test("dispose prevents an in-flight continuation from scheduling retries or committing turns", async () => {
+  let resolvePrompt: (() => void) | undefined
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+            await new Promise<void>((resolve) => {
+              resolvePrompt = resolve
+            })
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const context = { sessionID: "ses_dispose" } as never
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  void hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_dispose" } } as never })
+  await waitFor(() => calls.length === 1)
+
+  // Dispose while the prompt is in flight.
+  await hooks.dispose?.()
+  resolvePrompt?.()
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  // No new timer/continuation and the reserved-but-not-delivered turn is rolled
+  // back so it neither consumes an autoTurn nor commits a continuation.
+  expect(calls).toHaveLength(1)
+  expect((await getGoal("ses_dispose"))?.autoTurns).toBe(0)
+  expect((await getGoalInternal("ses_dispose"))?.pendingAttempt).toBeNull()
+})
+
+test("dispose while a prompt is in flight rolls back on rejection without a failure", async () => {
+  let resolvePrompt: (() => void) | undefined
+  const logs: unknown[] = []
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        app: { log: async (input: unknown) => logs.push(input) },
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+            await new Promise<void>((resolve) => {
+              resolvePrompt = resolve
+            })
+            throw new Error("network down")
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const sessionID = "ses_dispose_reject"
+  const context = { sessionID } as never
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  void hooks.event!({ event: { type: "session.idle", properties: { sessionID } } as never })
+  await waitFor(() => calls.length === 1)
+
+  // Dispose while the prompt is in flight, then let the prompt fail: the catch
+  // block must roll back the reserved attempt instead of counting a transport
+  // failure, scheduling a retry, or consuming an auto-turn.
+  await hooks.dispose?.()
+  resolvePrompt?.()
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(calls).toHaveLength(1)
+  expect(logs).toHaveLength(0)
+  expect((await getGoal(sessionID))?.autoTurns).toBe(0)
+  expect((await getGoal(sessionID))?.continuationFailures).toBe(0)
+  expect((await getGoal(sessionID))?.status).toBe("active")
+  expect((await getGoalInternal(sessionID))?.pendingAttempt).toBeNull()
+})
+
+test("the public goal tool result never exposes internal pending attempt fields", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const context = { sessionID: "ses_no_leak" } as never
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await reserveContinuation("ses_no_leak", 10, 0)
+  await recordContinuationResult("ses_no_leak", "success", 5)
+
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  const text = String(read)
+  expect(text).not.toContain("pendingAttempt")
+  expect(text).not.toContain("pendingContinuationStart")
+  expect(text).not.toContain("pendingContinuationStarted")
 })

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, beforeEach, expect, setSystemTime, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import plugin from "../src/server"
+import {
+  getGoal,
+  recordContinuationResult,
+  reserveContinuation,
+} from "../src/state"
 
 function requireTool<T>(tool: T | undefined, name: string): T {
   if (!tool) throw new Error(`expected ${name} to be registered`)
@@ -16,6 +21,15 @@ async function waitFor(predicate: () => boolean) {
     await new Promise((resolve) => setTimeout(resolve, 5))
   }
   expect(predicate()).toBe(true)
+}
+
+async function waitForLong(predicate: () => boolean | Promise<boolean>, deadlineMs = 3000) {
+  const deadline = Date.now() + deadlineMs
+  while (Date.now() < deadline) {
+    if (await predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  expect(await predicate()).toBe(true)
 }
 
 async function waitForContinuation(calls: unknown[]) {
@@ -274,6 +288,20 @@ OpenCode goal mode policy:
       usageContext,
     )
     await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_usage" } } as never })
+    // The continuation turn completes with a real assistant message, which
+    // resolves the pending continuation; the next idle then consumes the
+    // auto-turn limit and requests the wrap-up.
+    await hooks["experimental.chat.messages.transform"]!(
+      {},
+      {
+        messages: [
+          {
+            info: { id: "msg_usage_turn", role: "assistant", sessionID: "ses_usage" },
+            parts: [{ type: "text", text: "USAGE_TURN_SHOULD_NOT_LEAK" }],
+          },
+        ],
+      } as never,
+    )
     await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_usage" } } as never })
     const usageLimited = await requireTool(tools.get_goal, "get_goal").execute({}, usageContext)
     expect(String(usageLimited)).toContain('"status": "usageLimited"')
@@ -616,7 +644,7 @@ test("turn watchdog retries a busy active goal without consuming continuation bu
         },
       },
     } as never,
-    { auto_continue: false, max_turn_time: 0.02, max_auto_turns: 1, max_prompt_failures: 1 },
+    { auto_continue: false, max_turn_time: 0.02, max_auto_turns: 1, max_prompt_failures: 5 },
   )
   const tools = hooks.tool
   if (!tools) throw new Error("expected goal tools to be registered")
@@ -638,11 +666,27 @@ test("turn watchdog retries a busy active goal without consuming continuation bu
   expect(String(read)).toContain('"autoTurns": 0')
   expect(String(read)).toContain('"continuationFailures": 0')
   expect(String(read)).toContain('"awaitingContinuationProgress": false')
+  // A watchdog-delivered prompt is already inside a busy episode, so the
+  // pending attempt is marked started immediately.
+  expect(String(read)).toContain('"pendingContinuationStarted": true')
 
+  // The busy episode ends. Auto-continue is disabled here, so nothing further
+  // happens on idle; the watchdog-delivered attempt stays pending and started.
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  const afterIdle = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(afterIdle)).toContain('"status": "active"')
+  expect(String(afterIdle)).toContain('"autoTurns": 0')
+  expect(String(afterIdle)).toContain('"continuationFailures": 1')
+  expect(String(afterIdle)).toContain('"pendingContinuationStart": null')
+
+  // A new busy episode rescues again, still without auto-turn budgets.
   await hooks.event!({
     event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
   })
   await waitFor(() => calls.length === 2)
+  const final = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(final)).toContain('"status": "active"')
+  expect(String(final)).toContain('"autoTurns": 0')
 })
 
 test("turn watchdog resets when another busy turn starts", async () => {
@@ -787,7 +831,7 @@ test("turn watchdog does not inject while tasks are active, the goal is paused, 
   expect(calls).toHaveLength(0)
 })
 
-test("turn watchdog transport failures do not pause or charge the goal", async () => {
+test("turn watchdog transport failures share the prompt-failure ceiling without charging auto-turns", async () => {
   const logs: unknown[] = []
   const hooks = await plugin.server(
     {
@@ -800,7 +844,7 @@ test("turn watchdog transport failures do not pause or charge the goal", async (
         },
       },
     } as never,
-    { auto_continue: false, max_turn_time: 0.02, max_prompt_failures: 1 },
+    { auto_continue: false, max_turn_time: 0.02, max_prompt_failures: 2 },
   )
   const tools = hooks.tool
   if (!tools) throw new Error("expected goal tools to be registered")
@@ -812,11 +856,32 @@ test("turn watchdog transport failures do not pause or charge the goal", async (
   })
   await waitFor(() => logs.length === 1)
 
-  const read = await requireTool(tools.get_goal, "get_goal").execute({}, context)
-  expect(String(read)).toContain('"status": "active"')
-  expect(String(read)).toContain('"autoTurns": 0')
-  expect(String(read)).toContain('"continuationFailures": 0')
+  const afterFirst = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(afterFirst)).toContain('"status": "active"')
+  expect(String(afterFirst)).toContain('"autoTurns": 0')
+  expect(String(afterFirst)).toContain('"continuationFailures": 1')
   expect(JSON.stringify(logs[0])).toContain("Turn watchdog retry failed")
+
+  // Duplicate busy notifications in the same episode cannot re-arm a failed
+  // rescue.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 80))
+  expect(logs).toHaveLength(1)
+
+  // A new busy episode gets one rescue; its failure reaches the ceiling.
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
+  })
+  await waitFor(() => logs.length === 2)
+
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(read)).toContain('"status": "paused"')
+  expect(String(read)).toContain('"autoTurns": 0')
+  expect(String(read)).toContain('"continuationFailures": 2')
+  expect(String(read)).toContain("Auto-continue prompt failed repeatedly")
 })
 
 test("running task defers idle auto-continue", async () => {
@@ -1661,4 +1726,809 @@ test("idle handler skips overlapping continuations for the same session", async 
   await first
 
   expect(calls).toHaveLength(1)
+})
+
+test("auto-continue retries are bounded: three failed attempts, no fourth", async () => {
+  const logs: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        app: { log: async (input: unknown) => logs.push(input) },
+        session: {
+          promptAsync: async () => {
+            throw new Error("network down")
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 10, min_continue_interval_seconds: 0, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+
+  await waitForLong(() => logs.length === 3)
+  await new Promise((resolve) => setTimeout(resolve, 300))
+
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(String(read)).toContain('"status": "paused"')
+  expect(String(read)).toContain('"continuationFailures": 3')
+  expect(String(read)).toContain('"autoTurns": 3')
+  expect(logs).toHaveLength(3)
+})
+
+test("failed continuation retries wait for the configured minimum interval", async () => {
+  const logs: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        app: { log: async (input: unknown) => logs.push(input) },
+        session: {
+          promptAsync: async () => {
+            throw new Error("fetch failed")
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 1, max_prompt_failures: 2 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, { sessionID: "ses_1" } as never)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  await waitFor(() => logs.length === 1)
+
+  const early = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(String(early)).toContain('"continuationFailures": 1')
+
+  await new Promise((resolve) => setTimeout(resolve, 400))
+  const beforeInterval = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(String(beforeInterval)).toContain('"continuationFailures": 1')
+
+  await waitForLong(() => logs.length === 2)
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: "ses_1" } as never)
+  expect(String(read)).toContain('"status": "paused"')
+  expect(String(read)).toContain('"continuationFailures": 2')
+})
+
+test("recognized transport error strings accumulate as continuation failures", async () => {
+  const errors = [
+    "network down",
+    "fetch failed",
+    "ECONNRESET: connection reset by peer",
+    "request timed out",
+    "Cannot connect to API: The socket connection was closed unexpectedly.",
+    "Provider response headers timed out after 10000ms",
+  ]
+  for (const [index, message] of errors.entries()) {
+    const hooks = await plugin.server(
+      {
+        client: {
+          session: {
+            promptAsync: async () => {
+              throw new Error(message)
+            },
+          },
+        },
+      } as never,
+      { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0, max_prompt_failures: 10 },
+    )
+    const tools = hooks.tool
+    if (!tools) throw new Error("expected goal tools to be registered")
+
+    await requireTool(tools.create_goal, "create_goal").execute(
+      { objective: "keep going" },
+      { sessionID: `ses_transport_${index}` } as never,
+    )
+    await hooks.event!({
+      event: { type: "session.idle", properties: { sessionID: `ses_transport_${index}` } } as never,
+    })
+
+    const read = await requireTool(tools.get_goal, "get_goal").execute({}, { sessionID: `ses_transport_${index}` } as never)
+    expect(String(read)).toContain('"continuationFailures": 1')
+  }
+})
+
+test("failed tool output does not reset prompt failures; successful tool output does", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_1" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await recordContinuationResult("ses_1", "failure", 5)
+  await recordContinuationResult("ses_1", "success", 5)
+  expect((await getGoal("ses_1"))?.continuationFailures).toBe(1)
+
+  await hooks["tool.execute.after"]!(
+    { tool: "bash", sessionID: "ses_1", callID: "call_1", args: {} } as never,
+    { title: "bash", output: "<error>command not found</error>", metadata: {} } as never,
+  )
+  const afterFailedTool = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(afterFailedTool)).toContain('"continuationFailures": 1')
+
+  await hooks["tool.execute.after"]!(
+    { tool: "bash", sessionID: "ses_1", callID: "call_2", args: {} } as never,
+    { title: "bash", output: "tests passed", metadata: {} } as never,
+  )
+  const afterSuccessfulTool = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(afterSuccessfulTool)).toContain('"continuationFailures": 0')
+  expect(String(afterSuccessfulTool)).toContain('"pendingContinuationStart": null')
+})
+
+test("duplicate idle events before any busy never count a failure or send a duplicate", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0, max_prompt_failures: 1 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_1" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  // Paired duplicate idle: the continuation prompt was delivered but no busy
+  // event has marked it started, so it must neither count an unresolved
+  // failure nor send a second prompt.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "idle" } } } as never,
+  })
+
+  expect(calls).toHaveLength(1)
+  const read = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(read)).toContain('"status": "active"')
+  expect(String(read)).toContain('"continuationFailures": 0')
+  expect(String(read)).toContain('"pendingContinuationStarted": false')
+  expect(String(read)).not.toContain('"pendingContinuationStart": null')
+})
+
+test("paired idle events after a busy count exactly one unresolved failure and pause at the ceiling", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0, max_prompt_failures: 1 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_1" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  expect(calls).toHaveLength(1)
+
+  // The provider picks up the prompt: the busy event marks the attempt started.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
+  })
+  const started = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(started)).toContain('"pendingContinuationStarted": true')
+
+  // The following logical idle has no substantive progress: exactly one
+  // unresolved failure is counted, which hits the ceiling and pauses.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "idle" } } } as never,
+  })
+  const afterIdle = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(afterIdle)).toContain('"status": "paused"')
+  expect(String(afterIdle)).toContain('"continuationFailures": 1')
+  expect(String(afterIdle)).toContain('"autoTurns": 1')
+
+  // The paired session.idle duplicate must not double-count or double-send.
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  const final = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(final)).toContain('"continuationFailures": 1')
+  expect(calls).toHaveLength(1)
+})
+
+test("concurrent session.error transport events count at most one failure per pending attempt", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_1" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 3)
+  expect((await getGoal("ses_1"))?.pendingContinuationStart).not.toBeNull()
+
+  const transportEvent = {
+    event: {
+      type: "session.error",
+      properties: {
+        sessionID: "ses_1",
+        error: { name: "AI_APICallError", message: "Cannot connect to API: The socket connection was closed unexpectedly." },
+      },
+    } as never,
+  }
+  await Promise.all([hooks.event!(transportEvent), hooks.event!(transportEvent)])
+  const afterFirst = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(afterFirst)).toContain('"status": "active"')
+  expect(String(afterFirst)).toContain('"continuationFailures": 1')
+
+  // With no pending attempt left, duplicate transport events must not
+  // increment the counter repeatedly.
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: {
+        sessionID: "ses_1",
+        error: { name: "ProviderHeaderTimeoutError", message: "Provider response headers timed out after 10000ms" },
+      },
+    } as never,
+  })
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: {
+        sessionID: "ses_1",
+        error: { name: "ProviderHeaderTimeoutError", message: "Provider response headers timed out after 10000ms" },
+      },
+    } as never,
+  })
+  const final = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(final)).toContain('"continuationFailures": 1')
+})
+
+test("auto_continue false never schedules a retry after a transport event", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: false, min_continue_interval_seconds: 0, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_no_auto" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await reserveContinuation("ses_no_auto", 10, 0)
+  await recordContinuationResult("ses_no_auto", "success", 3)
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: { sessionID: "ses_no_auto", error: { message: "network connection failed" } },
+    } as never,
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  expect(calls).toHaveLength(0)
+  expect((await getGoal("ses_no_auto"))?.continuationFailures).toBe(1)
+})
+
+test("a repeated old assistant message cannot hide a no-response failure", async () => {
+  const calls: unknown[] = []
+  const oldAssistant = {
+    info: { id: "msg_old", role: "assistant", sessionID: "ses_old_message" },
+    parts: [{ type: "text", text: "Earlier progress" }],
+  }
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          messages: async () => ({ data: [oldAssistant] }),
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 1 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const context = { sessionID: "ses_old_message" } as never
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_old_message" } } as never })
+  expect(calls).toHaveLength(1)
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_old_message", status: { type: "busy" } } } as never,
+  })
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_old_message", status: { type: "idle" } } } as never,
+  })
+
+  const result = await getGoal("ses_old_message")
+  expect(result?.status).toBe("paused")
+  expect(result?.continuationFailures).toBe(1)
+  expect(calls).toHaveLength(1)
+})
+
+test("non-transport prompt errors preserve failure accounting without automatic retry", async () => {
+  const logs: unknown[] = []
+  let calls = 0
+  const hooks = await plugin.server(
+    {
+      client: {
+        app: { log: async (input: unknown) => logs.push(input) },
+        session: {
+          promptAsync: async () => {
+            calls += 1
+            throw new Error("invalid provider configuration")
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const context = { sessionID: "ses_non_transport" } as never
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_non_transport" } } as never })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(calls).toBe(1)
+  expect(logs).toHaveLength(1)
+  expect((await getGoal("ses_non_transport"))?.continuationFailures).toBe(1)
+})
+
+test("session.error without a pending attempt schedules recovery without a phantom failure", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0, max_prompt_failures: 3 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_1" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: {
+        sessionID: "ses_1",
+        error: { name: "AI_APICallError", message: "Cannot connect to API: The socket connection was closed unexpectedly." },
+      },
+    } as never,
+  })
+
+  const afterError = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(afterError)).toContain('"status": "active"')
+  expect(String(afterError)).toContain('"continuationFailures": 0')
+
+  // The first bounded automatic recovery starts without charging a failure.
+  await waitForLong(() => calls.length === 1)
+  const recovered = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(recovered)).toContain('"status": "active"')
+  expect(String(recovered)).toContain('"continuationFailures": 0')
+  expect(String(recovered)).toContain('"autoTurns": 1')
+})
+
+test("restart resolves a persisted started pending attempt at the next idle", async () => {
+  const firstCalls: unknown[] = []
+  const hooks1 = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            firstCalls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0, max_prompt_failures: 2 },
+  )
+  const tools1 = hooks1.tool
+  if (!tools1) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_1" } as never
+  await requireTool(tools1.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await hooks1.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  await waitFor(() => firstCalls.length === 1)
+  await hooks1.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
+  })
+  await hooks1.dispose?.()
+
+  // A fresh instance reads the same persisted state: the started=true pending
+  // attempt must be resolvable by the next idle after the restart.
+  const calls2: unknown[] = []
+  const hooks2 = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls2.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0, max_prompt_failures: 2 },
+  )
+  const tools2 = hooks2.tool
+  if (!tools2) throw new Error("expected goal tools to be registered")
+
+  await hooks2.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  const read = await requireTool(tools2.get_goal, "get_goal").execute({}, context)
+  expect(String(read)).toContain('"continuationFailures": 1')
+
+  // The bounded retry then sends the next continuation attempt.
+  await waitForLong(() => calls2.length === 1)
+  const retried = await requireTool(tools2.get_goal, "get_goal").execute({}, context)
+  expect(String(retried)).toContain('"continuationFailures": 1')
+})
+
+test("persisted started=false pending attempts go stale after restart", async () => {
+  const hooks1 = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0, max_prompt_failures: 2 },
+  )
+  const tools1 = hooks1.tool
+  if (!tools1) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_1" } as never
+  await requireTool(tools1.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5)
+  expect((await getGoal("ses_1"))?.pendingContinuationStarted).toBe(false)
+
+  // Simulate an old persisted attempt by writing a stale millisecond timestamp
+  // directly into the state file instead of waiting 30 seconds.
+  const file = process.env.OPENCODE_GOAL_STATE_PATH!
+  const state = JSON.parse(await readFile(file, "utf8"))
+  state.goals.ses_1.pendingContinuationStart = Date.now() - 60_000
+  state.goals.ses_1.pendingContinuationStarted = false
+  await writeFile(file, JSON.stringify(state))
+  await hooks1.dispose?.()
+
+  const calls: unknown[] = []
+  const hooks2 = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, max_auto_turns: 5, min_continue_interval_seconds: 0, max_prompt_failures: 2 },
+  )
+  const tools2 = hooks2.tool
+  if (!tools2) throw new Error("expected goal tools to be registered")
+
+  await hooks2.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  const stale = await requireTool(tools2.get_goal, "get_goal").execute({}, context)
+  expect(String(stale)).toContain('"status": "active"')
+  expect(String(stale)).toContain('"continuationFailures": 1')
+
+  // The stale attempt triggers a bounded retry rather than wedging forever.
+  await waitForLong(() => calls.length === 1)
+})
+
+test("a locally delivered unstarted attempt never becomes a false no-response failure", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0, max_prompt_failures: 1 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const context = { sessionID: "ses_local_pending" } as never
+
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_local_pending" } } as never })
+  expect(calls).toHaveLength(1)
+
+  const file = process.env.OPENCODE_GOAL_STATE_PATH!
+  const state = JSON.parse(await readFile(file, "utf8"))
+  state.goals.ses_local_pending.pendingContinuationStart = Date.now() - 60_000
+  await writeFile(file, JSON.stringify(state))
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_local_pending", status: { type: "idle" } } } as never,
+  })
+
+  const goal = await getGoal("ses_local_pending")
+  expect(goal?.status).toBe("active")
+  expect(goal?.continuationFailures).toBe(0)
+  expect(calls).toHaveLength(1)
+})
+
+test("a built-in retry status cancels scheduled transport recovery", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  await requireTool(tools.create_goal, "create_goal").execute(
+    { objective: "keep going" },
+    { sessionID: "ses_native_retry" } as never,
+  )
+
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: { sessionID: "ses_native_retry", error: { message: "network connection failed" } },
+    } as never,
+  })
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_native_retry", status: { type: "retry" } } } as never,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(calls).toHaveLength(0)
+  expect((await getGoal("ses_native_retry"))?.continuationFailures).toBe(0)
+})
+
+test("assistant progress cancels no-pending transport recovery", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const context = { sessionID: "ses_progress_recovery" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: { sessionID: "ses_progress_recovery", error: { message: "network connection failed" } },
+    } as never,
+  })
+  await hooks.event!({
+    event: {
+      type: "message.updated",
+      properties: {
+        sessionID: "ses_progress_recovery",
+        message: {
+          info: { id: "msg_recovered", role: "assistant", sessionID: "ses_progress_recovery" },
+          parts: [{ type: "text", text: "The provider recovered without plugin intervention." }],
+        },
+      },
+    } as never,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(calls).toHaveLength(0)
+})
+
+test("successful tool progress cancels no-pending transport recovery", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  const context = { sessionID: "ses_tool_recovery" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: { sessionID: "ses_tool_recovery", error: { message: "network connection failed" } },
+    } as never,
+  })
+  await hooks["tool.execute.after"]!(
+    { tool: "bash", sessionID: "ses_tool_recovery", callID: "call_progress", args: {} } as never,
+    { title: "bash", output: "tests passed", metadata: {} } as never,
+  )
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(calls).toHaveLength(0)
+})
+
+test("interrupted connection messages are not classified as transport recovery", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: true, min_continue_interval_seconds: 0 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+  await requireTool(tools.create_goal, "create_goal").execute(
+    { objective: "keep going" },
+    { sessionID: "ses_interrupted" } as never,
+  )
+
+  await hooks.event!({
+    event: {
+      type: "session.error",
+      properties: { sessionID: "ses_interrupted", error: { message: "socket connection interrupted by user" } },
+    } as never,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  expect(calls).toHaveLength(0)
+  expect((await getGoal("ses_interrupted"))?.continuationFailures).toBe(0)
+})
+
+test("tool progress honors completed states and never resets on failed or incomplete tools", async () => {
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async () => {},
+        },
+      },
+    } as never,
+    { auto_continue: false },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_1" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await recordContinuationResult("ses_1", "failure", 5)
+  expect((await getGoal("ses_1"))?.continuationFailures).toBe(1)
+
+  const fireTool = (output: unknown) =>
+    hooks["tool.execute.after"]!(
+      { tool: "bash", sessionID: "ses_1", callID: `call_${Math.random()}`, args: {} } as never,
+      output as never,
+    )
+
+  await hooks["tool.execute.after"]!(
+    { tool: "get_goal", sessionID: "ses_1", callID: "call_get_goal", args: {} } as never,
+    { title: "get_goal", output: '{"goal":{"status":"active"}}', metadata: {} } as never,
+  )
+  expect((await getGoal("ses_1"))?.continuationFailures).toBe(1)
+
+  // Incomplete, failed, cancelled, and aborted states must not reset even
+  // without an error string.
+  await fireTool({ title: "bash", output: "task_id: t1\nstate: running", metadata: {} })
+  await fireTool({ title: "bash", output: "task_id: t1\nstate: failed", metadata: {} })
+  await fireTool({ title: "bash", output: "task_id: t1\nstate: cancelled", metadata: {} })
+  await fireTool({ title: "task", output: '<task id="t1" state="error">failed</task>', metadata: {} })
+  await fireTool({ title: "bash", output: "nope", state: "aborted", metadata: {} })
+  await fireTool({ title: "bash", output: "nope", status: "running", metadata: {} })
+  await fireTool({ title: "bash", output: "nope", success: false, metadata: {} })
+  const unchanged = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(unchanged)).toContain('"continuationFailures": 1')
+
+  // Completed and plain successful outputs reset the failure counter.
+  await fireTool({ title: "bash", output: "task_id: t1\nstate: completed\n\n<task_result>done</task_result>", metadata: {} })
+  const completed = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(completed)).toContain('"continuationFailures": 0')
+
+  await fireTool({ title: "bash", output: "tests passed", metadata: {} })
+  const plainSuccess = await requireTool(tools.get_goal, "get_goal").execute({}, context)
+  expect(String(plainSuccess)).toContain('"continuationFailures": 0')
+})
+
+test("watchdog rescues at most once per busy episode", async () => {
+  const calls: unknown[] = []
+  const hooks = await plugin.server(
+    {
+      client: {
+        session: {
+          promptAsync: async (input: unknown) => {
+            calls.push(input)
+          },
+        },
+      },
+    } as never,
+    { auto_continue: false, max_turn_time: 0.02, max_prompt_failures: 5 },
+  )
+  const tools = hooks.tool
+  if (!tools) throw new Error("expected goal tools to be registered")
+
+  const context = { sessionID: "ses_1" } as never
+  await requireTool(tools.create_goal, "create_goal").execute({ objective: "keep going" }, context)
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
+  })
+  await waitForContinuation(calls)
+  expect(calls).toHaveLength(1)
+
+  // Another busy event inside the same episode must not re-arm the watchdog.
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
+  })
+  await new Promise((resolve) => setTimeout(resolve, 80))
+  expect(calls).toHaveLength(1)
+
+  // Ending the episode and starting a new one rescues again.
+  await hooks.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
+  await hooks.event!({
+    event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
+  })
+  await waitFor(() => calls.length === 2)
+  expect(calls).toHaveLength(2)
 })

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -7,12 +7,14 @@ import {
   clearGoal,
   completeGoal,
   createGoal,
+  markPendingContinuationStarted,
   recordAssistantProgress,
   getGoal,
   markGoalUnmet,
   pauseGoalForPlanMode,
   recordContinuationResult,
   recordPromptAgent,
+  recordToolProgress,
   reserveContinuation,
   setGoalStatus,
   updateGoalObjective,
@@ -278,4 +280,161 @@ test("does not overwrite corrupt persisted state", async () => {
   await expect(createGoal("ses_1", "ship the plugin", null)).rejects.toThrow()
 
   expect(await readFile(process.env.OPENCODE_GOAL_STATE_PATH!, "utf8")).toBe("{not valid json")
+})
+
+test("prompt delivery arms the pending window but never resets the failure count", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "failure", 5)
+  await recordContinuationResult("ses_1", "failure", 5)
+
+  const delivered = await recordContinuationResult("ses_1", "success", 5)
+  expect(delivered?.continuationFailures).toBe(2)
+  expect(delivered?.pendingContinuationStart).not.toBeNull()
+  expect(delivered?.pendingContinuationStarted).toBe(false)
+  expect(delivered?.awaitingContinuationProgress).toBe(true)
+
+  const failed = await recordContinuationResult("ses_1", "failure", 5)
+  expect(failed?.continuationFailures).toBe(3)
+  expect(failed?.pendingContinuationStart).toBeNull()
+  expect(failed?.pendingContinuationStarted).toBe(false)
+  expect(failed?.awaitingContinuationProgress).toBe(false)
+})
+
+test("a session busy event marks the pending attempt as started", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5)
+  expect((await getGoal("ses_1"))?.pendingContinuationStarted).toBe(false)
+
+  const started = await markPendingContinuationStarted("ses_1")
+  expect(started?.pendingContinuationStarted).toBe(true)
+
+  // Marking an already-started or absent attempt is idempotent.
+  const again = await markPendingContinuationStarted("ses_1")
+  expect(again?.pendingContinuationStarted).toBe(true)
+  await recordContinuationResult("ses_1", "failure", 5)
+  expect((await markPendingContinuationStarted("ses_1"))?.pendingContinuationStart).toBeNull()
+})
+
+test("persists continuation failures and the pending window across restart", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5)
+  await recordContinuationResult("ses_1", "failure", 5)
+  await recordContinuationResult("ses_1", "failure", 5)
+
+  // getGoal re-reads the persisted state file, simulating a process restart.
+  const reloaded = await getGoal("ses_1")
+  expect(reloaded?.continuationFailures).toBe(2)
+  expect(reloaded?.pendingContinuationStart).toBeNull()
+  expect(reloaded?.pendingContinuationStarted).toBe(false)
+
+  await recordContinuationResult("ses_1", "success", 5)
+  const reloadedPending = await getGoal("ses_1")
+  expect(reloadedPending?.continuationFailures).toBe(2)
+  expect(reloadedPending?.pendingContinuationStart).toBeGreaterThanOrEqual(Date.now() - 5_000)
+  expect(reloadedPending?.pendingContinuationStarted).toBe(false)
+
+  await markPendingContinuationStarted("ses_1")
+  const reloadedStarted = await getGoal("ses_1")
+  expect(reloadedStarted?.pendingContinuationStarted).toBe(true)
+  expect(reloadedStarted?.pendingContinuationStart).not.toBeNull()
+})
+
+test("decodes persisted state that lacks the retry fields", async () => {
+  await writeFile(
+    process.env.OPENCODE_GOAL_STATE_PATH!,
+    JSON.stringify({
+      version: 1,
+      goals: {
+        ses_1: {
+          sessionID: "ses_1",
+          objective: "continue",
+          status: "active",
+          tokenBudget: null,
+          tokensUsed: 0,
+          timeUsedSeconds: 0,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAccountedAt: 1,
+          autoTurns: 0,
+          lastContinuationAt: null,
+        },
+      },
+    }),
+  )
+
+  const goal = await getGoal("ses_1")
+
+  expect(goal?.continuationFailures).toBe(0)
+  expect(goal?.pendingContinuationStart).toBeNull()
+  expect(goal?.pendingContinuationStarted).toBe(false)
+})
+
+test("substantive assistant text resets the failure count and pending window", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "failure", 5)
+  await recordContinuationResult("ses_1", "failure", 5)
+  await recordContinuationResult("ses_1", "success", 5)
+  expect((await getGoal("ses_1"))?.pendingContinuationStart).not.toBeNull()
+
+  const progressed = await recordAssistantProgress("ses_1", {
+    messageID: "m1",
+    text: "Implemented the parser and added passing tests",
+    outputTokens: 400,
+  })
+
+  expect(progressed?.continuationFailures).toBe(0)
+  expect(progressed?.pendingContinuationStart).toBeNull()
+  expect(progressed?.status).toBe("active")
+})
+
+test("successful tool output resets failures and clears the pending window", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await recordContinuationResult("ses_1", "failure", 5)
+  await recordContinuationResult("ses_1", "success", 5)
+  expect((await getGoal("ses_1"))?.continuationFailures).toBe(1)
+
+  const progressed = await recordToolProgress("ses_1", "tests passed")
+
+  expect(progressed?.continuationFailures).toBe(0)
+  expect(progressed?.pendingContinuationStart).toBeNull()
+  expect(progressed?.awaitingContinuationProgress).toBe(false)
+})
+
+test("re-reading the previous assistant message does not resolve a pending continuation", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await recordAssistantProgress("ses_1", { messageID: "m1", text: "Initial progress" })
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5)
+
+  const repeated = await recordAssistantProgress("ses_1", {
+    messageID: "m1",
+    text: "Initial progress",
+    evaluateContinuation: true,
+  })
+
+  expect(repeated?.pendingContinuationStart).not.toBeNull()
+  expect(repeated?.awaitingContinuationProgress).toBe(true)
+})
+
+test("lastContinuationAt remains a public seconds timestamp", async () => {
+  await createGoal("ses_1", "keep going", null)
+  const reserved = await reserveContinuation("ses_1", 10, 0)
+
+  expect(reserved?.lastContinuationAt).toBe(Math.floor(Date.now() / 1000))
+  expect(reserved?.lastContinuationAt).toBeLessThan(1_000_000_000_000)
+})
+
+test("resuming a paused goal clears the failure count and pending window", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await recordContinuationResult("ses_1", "failure", 1)
+  expect((await getGoal("ses_1"))?.status).toBe("paused")
+
+  const resumed = await setGoalStatus("ses_1", "active")
+
+  expect(resumed?.continuationFailures).toBe(0)
+  expect(resumed?.pendingContinuationStart).toBeNull()
 })

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -10,12 +10,14 @@ import {
   markPendingContinuationStarted,
   recordAssistantProgress,
   getGoal,
+  getGoalInternal,
   markGoalUnmet,
   pauseGoalForPlanMode,
   recordContinuationResult,
   recordPromptAgent,
   recordToolProgress,
   reserveContinuation,
+  rollbackContinuationAttempt,
   setGoalStatus,
   updateGoalObjective,
 } from "../src/state"
@@ -290,14 +292,13 @@ test("prompt delivery arms the pending window but never resets the failure count
 
   const delivered = await recordContinuationResult("ses_1", "success", 5)
   expect(delivered?.continuationFailures).toBe(2)
-  expect(delivered?.pendingContinuationStart).not.toBeNull()
-  expect(delivered?.pendingContinuationStarted).toBe(false)
+  expect(delivered?.pendingAttempt).not.toBeNull()
+  expect(delivered?.pendingAttempt?.started).toBe(false)
   expect(delivered?.awaitingContinuationProgress).toBe(true)
 
   const failed = await recordContinuationResult("ses_1", "failure", 5)
   expect(failed?.continuationFailures).toBe(3)
-  expect(failed?.pendingContinuationStart).toBeNull()
-  expect(failed?.pendingContinuationStarted).toBe(false)
+  expect(failed?.pendingAttempt).toBeNull()
   expect(failed?.awaitingContinuationProgress).toBe(false)
 })
 
@@ -305,16 +306,35 @@ test("a session busy event marks the pending attempt as started", async () => {
   await createGoal("ses_1", "keep going", null)
   await reserveContinuation("ses_1", 10, 0)
   await recordContinuationResult("ses_1", "success", 5)
-  expect((await getGoal("ses_1"))?.pendingContinuationStarted).toBe(false)
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt?.started).toBe(false)
 
   const started = await markPendingContinuationStarted("ses_1")
-  expect(started?.pendingContinuationStarted).toBe(true)
+  expect(started?.pendingAttempt?.started).toBe(true)
 
   // Marking an already-started or absent attempt is idempotent.
   const again = await markPendingContinuationStarted("ses_1")
-  expect(again?.pendingContinuationStarted).toBe(true)
+  expect(again?.pendingAttempt?.started).toBe(true)
   await recordContinuationResult("ses_1", "failure", 5)
-  expect((await markPendingContinuationStarted("ses_1"))?.pendingContinuationStart).toBeNull()
+  expect((await markPendingContinuationStarted("ses_1"))?.pendingAttempt).toBeNull()
+})
+
+test("markPendingContinuationStarted on a goal-less busy event does not create state", async () => {
+  // No goal exists for this session, so a busy event must not create a state
+  // file nor rewrite anything.
+  expect(await markPendingContinuationStarted("ses_nogoal")).toBeNull()
+  await expect(readFile(process.env.OPENCODE_GOAL_STATE_PATH!, "utf8")).rejects.toThrow()
+})
+
+test("markPendingContinuationStarted does not rewrite state when nothing is pending", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await markPendingContinuationStarted("ses_1")
+  const mtime = (await stat(process.env.OPENCODE_GOAL_STATE_PATH!)).mtimeMs
+
+  // A busy with no pending attempt (or an already-started one) must be a
+  // read-only no-op and must not rewrite the state file.
+  await markPendingContinuationStarted("ses_1")
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  expect((await stat(process.env.OPENCODE_GOAL_STATE_PATH!)).mtimeMs).toBe(mtime)
 })
 
 test("persists continuation failures and the pending window across restart", async () => {
@@ -324,22 +344,21 @@ test("persists continuation failures and the pending window across restart", asy
   await recordContinuationResult("ses_1", "failure", 5)
   await recordContinuationResult("ses_1", "failure", 5)
 
-  // getGoal re-reads the persisted state file, simulating a process restart.
-  const reloaded = await getGoal("ses_1")
+  // getGoalInternal re-reads the persisted state file, simulating a restart.
+  const reloaded = await getGoalInternal("ses_1")
   expect(reloaded?.continuationFailures).toBe(2)
-  expect(reloaded?.pendingContinuationStart).toBeNull()
-  expect(reloaded?.pendingContinuationStarted).toBe(false)
+  expect(reloaded?.pendingAttempt).toBeNull()
 
   await recordContinuationResult("ses_1", "success", 5)
-  const reloadedPending = await getGoal("ses_1")
+  const reloadedPending = await getGoalInternal("ses_1")
   expect(reloadedPending?.continuationFailures).toBe(2)
-  expect(reloadedPending?.pendingContinuationStart).toBeGreaterThanOrEqual(Date.now() - 5_000)
-  expect(reloadedPending?.pendingContinuationStarted).toBe(false)
+  expect(reloadedPending?.pendingAttempt?.reservedAt).toBeGreaterThanOrEqual(Date.now() - 5_000)
+  expect(reloadedPending?.pendingAttempt?.started).toBe(false)
 
   await markPendingContinuationStarted("ses_1")
-  const reloadedStarted = await getGoal("ses_1")
-  expect(reloadedStarted?.pendingContinuationStarted).toBe(true)
-  expect(reloadedStarted?.pendingContinuationStart).not.toBeNull()
+  const reloadedStarted = await getGoalInternal("ses_1")
+  expect(reloadedStarted?.pendingAttempt?.started).toBe(true)
+  expect(reloadedStarted?.pendingAttempt).not.toBeNull()
 })
 
 test("decodes persisted state that lacks the retry fields", async () => {
@@ -365,11 +384,10 @@ test("decodes persisted state that lacks the retry fields", async () => {
     }),
   )
 
-  const goal = await getGoal("ses_1")
+  const goal = await getGoalInternal("ses_1")
 
   expect(goal?.continuationFailures).toBe(0)
-  expect(goal?.pendingContinuationStart).toBeNull()
-  expect(goal?.pendingContinuationStarted).toBe(false)
+  expect(goal?.pendingAttempt).toBeNull()
 })
 
 test("substantive assistant text resets the failure count and pending window", async () => {
@@ -378,30 +396,73 @@ test("substantive assistant text resets the failure count and pending window", a
   await recordContinuationResult("ses_1", "failure", 5)
   await recordContinuationResult("ses_1", "failure", 5)
   await recordContinuationResult("ses_1", "success", 5)
-  expect((await getGoal("ses_1"))?.pendingContinuationStart).not.toBeNull()
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).not.toBeNull()
 
   const progressed = await recordAssistantProgress("ses_1", {
     messageID: "m1",
     text: "Implemented the parser and added passing tests",
     outputTokens: 400,
+    completedAt: Date.now(),
   })
 
   expect(progressed?.continuationFailures).toBe(0)
-  expect(progressed?.pendingContinuationStart).toBeNull()
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).toBeNull()
   expect(progressed?.status).toBe("active")
 })
 
-test("successful tool output resets failures and clears the pending window", async () => {
+test("successful tool output clears transport failures but preserves no-progress evaluation", async () => {
   await createGoal("ses_1", "keep going", null)
-  await recordContinuationResult("ses_1", "failure", 5)
-  await recordContinuationResult("ses_1", "success", 5)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5) // delivers: arms the no-progress window
+  await recordContinuationResult("ses_1", "failure", 5) // not delivered -> resolves window + counts
+  await recordContinuationResult("ses_1", "success", 5) // redelivers: arms the no-progress window again
   expect((await getGoal("ses_1"))?.continuationFailures).toBe(1)
+  expect((await getGoal("ses_1"))?.awaitingContinuationProgress).toBe(true)
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).not.toBeNull()
 
   const progressed = await recordToolProgress("ses_1", "tests passed")
 
+  // Tool progress clears the transport failure counter and pending window...
   expect(progressed?.continuationFailures).toBe(0)
-  expect(progressed?.pendingContinuationStart).toBeNull()
-  expect(progressed?.awaitingContinuationProgress).toBe(false)
+  expect(progressed?.pendingAttempt).toBeNull()
+  // ...but MUST NOT reset the armed no-progress evaluation: the tool ran inside
+  // a continuation turn, and the assistant's still-pending final text drives
+  // the low-output accounting.
+  expect(progressed?.awaitingContinuationProgress).toBe(true)
+  expect(progressed?.noProgressTurns).toBe(0)
+})
+
+test("recordToolProgress only clears the pending attempt captured for the same tool call", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5)
+  const attemptA = (await getGoalInternal("ses_1"))?.pendingAttempt?.id
+  expect(attemptA).toMatch(/^att_/)
+
+  // A newer attempt supersedes the one the (still-running) tool call started
+  // under; the delayed output must not clear it.
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5)
+  const attemptB = (await getGoalInternal("ses_1"))?.pendingAttempt?.id
+  expect(attemptB).not.toBe(attemptA)
+
+  const delayed = await recordToolProgress("ses_1", "tests passed", attemptA)
+  expect(delayed?.pendingAttempt?.id).toBe(attemptB)
+
+  // Output from a call that started while attempt B was pending clears it.
+  const cleared = await recordToolProgress("ses_1", "tests passed", attemptB)
+  expect(cleared?.pendingAttempt).toBeNull()
+
+  // A null capture (the tool call started with no pending attempt) cannot clear
+  // an attempt that appeared while the call was still running.
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5)
+  const protectedNow = await recordToolProgress("ses_1", "tests passed", null)
+  expect(protectedNow?.pendingAttempt).not.toBeNull()
+
+  // Omitting the expected id keeps the legacy unconditional reset.
+  const legacy = await recordToolProgress("ses_1", "tests passed")
+  expect(legacy?.pendingAttempt).toBeNull()
 })
 
 test("re-reading the previous assistant message does not resolve a pending continuation", async () => {
@@ -414,9 +475,10 @@ test("re-reading the previous assistant message does not resolve a pending conti
     messageID: "m1",
     text: "Initial progress",
     evaluateContinuation: true,
+    completedAt: Date.now(),
   })
 
-  expect(repeated?.pendingContinuationStart).not.toBeNull()
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).not.toBeNull()
   expect(repeated?.awaitingContinuationProgress).toBe(true)
 })
 
@@ -436,5 +498,76 @@ test("resuming a paused goal clears the failure count and pending window", async
   const resumed = await setGoalStatus("ses_1", "active")
 
   expect(resumed?.continuationFailures).toBe(0)
-  expect(resumed?.pendingContinuationStart).toBeNull()
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).toBeNull()
+})
+
+test("internal pending attempt fields are not exposed on the public snapshot", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5)
+
+  const publicGoal = await getGoal("ses_1")
+  expect(publicGoal).not.toHaveProperty("pendingAttempt")
+  expect(publicGoal).not.toHaveProperty("pendingContinuationStart")
+  expect(publicGoal).not.toHaveProperty("pendingContinuationStarted")
+  expect(JSON.stringify(publicGoal)).not.toContain("pendingAttempt")
+
+  // The dedicated internal API exposes the attempt lifecycle.
+  const internalGoal = await getGoalInternal("ses_1")
+  expect(internalGoal?.pendingAttempt).not.toBeNull()
+  expect(internalGoal?.pendingAttempt?.id).toMatch(/^att_/)
+})
+
+test("rolling back a reserved-but-not-delivered attempt restores autoTurns and lastContinuationAt", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await reserveContinuation("ses_1", 10, 0)
+  expect((await getGoal("ses_1"))?.autoTurns).toBe(1)
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt?.delivered).toBe(false)
+
+  const rolledBack = await rollbackContinuationAttempt("ses_1")
+  expect(rolledBack).toBe(true)
+  expect((await getGoal("ses_1"))?.autoTurns).toBe(0)
+  expect((await getGoal("ses_1"))?.lastContinuationAt).toBeNull()
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).toBeNull()
+
+  // Rolling back again (nothing left) is a no-op.
+  expect(await rollbackContinuationAttempt("ses_1")).toBe(false)
+})
+
+test("rolling back a delivered attempt is a no-op and does not un-consume the turn", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await reserveContinuation("ses_1", 10, 0)
+  await recordContinuationResult("ses_1", "success", 5)
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt?.delivered).toBe(true)
+
+  expect(await rollbackContinuationAttempt("ses_1")).toBe(false)
+  expect((await getGoal("ses_1"))?.autoTurns).toBe(1)
+})
+
+test("delayed prior-turn assistant output cannot clear a newer pending attempt", async () => {
+  await createGoal("ses_1", "keep going", null)
+  await recordAssistantProgress("ses_1", { messageID: "m_old", text: "Old work" })
+  const reserved = await reserveContinuation("ses_1", 10, 0)
+  const reservedAt = reserved?.pendingAttempt?.reservedAt ?? 0
+  await recordContinuationResult("ses_1", "success", 5)
+
+  // A delayed prior-turn message arrives late, completing BEFORE the attempt
+  // was reserved. Its messageID is new, so the repeated-message guard alone
+  // cannot reject it; the completedAt correlation must keep the pending
+  // attempt intact.
+  await recordAssistantProgress("ses_1", {
+    messageID: "m_delayed",
+    text: "Delayed old output that arrived late",
+    completedAt: reservedAt - 10_000,
+  })
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).not.toBeNull()
+  expect((await getGoal("ses_1"))?.continuationFailures).toBe(0)
+
+  // A newer message completing after the attempt resolves it.
+  await recordAssistantProgress("ses_1", {
+    messageID: "m_new",
+    text: "Current progress after the continuation",
+    completedAt: reservedAt + 10_000,
+  })
+  expect((await getGoalInternal("ses_1"))?.pendingAttempt).toBeNull()
 })


### PR DESCRIPTION
## Summary

- persist a correlated continuation-attempt lifecycle before prompt delivery, so busy/error/progress events and process restarts cannot lose or duplicate an attempt
- bound transport and unresolved no-response recovery in both OpenCode V1 and V2, respecting minimum intervals, native retries, task deferral, and the shared `max_prompt_failures` ceiling
- integrate watchdog rescues without consuming auto-turn or no-progress budgets, while still counting recognized transport/no-response failures
- roll back reservations canceled before delivery, but retain accepted prompts even if timer ownership changes in flight
- correlate assistant and tool progress to the attempt that produced it, preventing delayed prior-turn output from clearing newer retry state
- keep retry internals out of public goal snapshots/tool JSON and prevent disposed plugin generations from recreating timers

## Scope

This is the focused replacement for #19. It keeps package identity, public goal tools/statuses, state location, TUI behavior, prompts, safety defaults, and publishing unchanged. The implementation is rebased through the current dual V1/V2 release line and now applies the same bounded-recovery semantics to both plugin entrypoints.

The bounded-recovery design and live transport cases were adapted from @ruizkinio's work in #19. The original commit credits Sam Ruiz as co-author.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test` (155 passed)
- `bun run build`
- `bun run pack:dry-run` (5 published files)
- GitHub CI: lint, typecheck, tests/coverage, and build passed
- independent standards/specification review plus two read-only Claude Opus CLI review passes; all merge-blocking findings were addressed with regression coverage

## AI Assistance

Implemented and reviewed with OpenCode using code-worker/review subagents, then independently reviewed with Claude Opus through the Claude Code CLI. All generated changes were inspected and validated before push.