### PR TITLE
fix: restore the V2 TUI sidebar and palette command

### DIFF
--- a/src/tui.ts
+++ b/src/tui.ts
@@ -111,6 +111,61 @@ function box(props: Record<string, unknown>, children: ElementChild[] = []) {
   return element("box", props, children)
 }
 
+type SlotRender = (props: { sessionID: string }) => unknown
+type SlotDispose = () => void
+
+const noopDispose: SlotDispose = () => {}
+
+/**
+ * Registers a V2 TUI slot across both plugin-context generations.
+ *
+ * Early V2 previews exposed `ui.slot(name, render)`. Current previews expose a
+ * single options argument, `ui.slot({ append, render })`, and silently register
+ * nothing when handed the positional pair — which is how the goal sidebar and
+ * the palette keymap layer both disappeared. Branch on the callback arity so
+ * either host works, and tolerate hosts that return no disposer.
+ */
+export function registerSlotV2(context: TuiPluginV2.Context, name: string, render: SlotRender): SlotDispose {
+  const slot = context.ui.slot as unknown as (...args: unknown[]) => unknown
+  const dispose = slot.length <= 1 ? slot({ append: name, render }) : slot(name, render)
+  return typeof dispose === "function" ? (dispose as SlotDispose) : noopDispose
+}
+
+/**
+ * Reads a theme color by trying each candidate path in order, descending into a
+ * `default` leaf when the resolved node is a color group.
+ *
+ * Current previews expose a nested theme (`text.default`, `text.subdued`,
+ * `text.feedback.success`), while earlier previews and the V1 TUI expose flat
+ * keys (`text`, `textMuted`, `primary`). Passing a color *group* as `fg`
+ * renders nothing useful, so resolve to a leaf before handing it to OpenTUI.
+ */
+export function themeColorV2(theme: unknown, ...paths: readonly (readonly string[])[]): unknown {
+  for (const path of paths) {
+    let cursor: unknown = theme
+    for (const key of path) {
+      if (cursor === null || typeof cursor !== "object") {
+        cursor = undefined
+        break
+      }
+      cursor = (cursor as Record<string, unknown>)[key]
+    }
+    if (cursor !== null && typeof cursor === "object" && "default" in (cursor as Record<string, unknown>)) {
+      cursor = (cursor as Record<string, unknown>).default
+    }
+    if (cursor !== undefined && cursor !== null) return cursor
+  }
+  return undefined
+}
+
+function goalColorsV2(theme: unknown) {
+  return {
+    text: themeColorV2(theme, ["text", "default"], ["text"]),
+    muted: themeColorV2(theme, ["text", "subdued"], ["textMuted"]),
+    achieved: themeColorV2(theme, ["text", "feedback", "success"], ["primary"], ["text", "default"], ["text"]),
+  }
+}
+
 function goalSnapshotKey(sessionID: string) {
   return `goal-mode.snapshot.${sessionID}`
 }
@@ -498,7 +553,7 @@ async function showSummaryV2(api: TuiPluginV2.Context, sessionID: string, goal: 
 }
 
 function GoalSidebarV2(api: TuiPluginV2.Context, sessionID: string) {
-  const theme = api.theme
+  const colors = goalColorsV2(api.theme)
   const [cache, setCache] = api.storage.memory<{ goal: GoalSnapshot | null }>(`goal-mode.v2.${sessionID}`, {
     initial: { goal: null },
   })
@@ -523,26 +578,27 @@ function GoalSidebarV2(api: TuiPluginV2.Context, sessionID: string) {
     if (!snapshot) return null
     if (snapshot.status === "complete" || snapshot.status === "unmet") {
       const elapsed = liveTimeUsedSeconds(snapshot)
-      return text({ fg: snapshot.status === "complete" ? theme.primary : theme.textMuted }, [
+      return text({ fg: snapshot.status === "complete" ? colors.achieved : colors.muted }, [
         `${snapshot.status === "complete" ? "Goal achieved" : "Goal unmet"} (${formatDurationBadge(elapsed)})`,
       ])
     }
     return box({}, [
-      text({ fg: theme.text }, ["Goal"]),
-      text({ fg: theme.textMuted }, [`Status: ${snapshot.status}`]),
-      text({ fg: theme.textMuted }, [`Time: ${formatDuration(liveTimeUsedSeconds(snapshot, nowSeconds()))}`]),
-      text({ fg: theme.textMuted }, [`Tokens: ${snapshot.tokensUsed}${snapshot.tokenBudget == null ? "" : `/${snapshot.tokenBudget}`}`]),
-      text({ fg: theme.textMuted }, [`Auto-continues: ${snapshot.autoTurns}${snapshot.maxAutoTurns == null ? "" : `/${snapshot.maxAutoTurns}`}`]),
-      ...(snapshot.lastCheckpoint ? [text({ fg: theme.textMuted }, [`Checkpoint: ${snapshot.lastCheckpoint.summary}`])] : []),
-      ...(snapshot.stopReason ? [text({ fg: theme.textMuted }, [`Stop: ${snapshot.stopReason}`])] : []),
-      ...(snapshot.lastStatus ? [text({ fg: theme.textMuted }, [snapshot.lastStatus])] : []),
-      text({ fg: theme.textMuted }, [snapshot.objective]),
+      text({ fg: colors.text }, ["Goal"]),
+      text({ fg: colors.muted }, [`Status: ${snapshot.status}`]),
+      text({ fg: colors.muted }, [`Time: ${formatDuration(liveTimeUsedSeconds(snapshot, nowSeconds()))}`]),
+      text({ fg: colors.muted }, [`Tokens: ${snapshot.tokensUsed}${snapshot.tokenBudget == null ? "" : `/${snapshot.tokenBudget}`}`]),
+      text({ fg: colors.muted }, [`Auto-continues: ${snapshot.autoTurns}${snapshot.maxAutoTurns == null ? "" : `/${snapshot.maxAutoTurns}`}`]),
+      ...(snapshot.lastCheckpoint ? [text({ fg: colors.muted }, [`Checkpoint: ${snapshot.lastCheckpoint.summary}`])] : []),
+      ...(snapshot.stopReason ? [text({ fg: colors.muted }, [`Stop: ${snapshot.stopReason}`])] : []),
+      ...(snapshot.lastStatus ? [text({ fg: colors.muted }, [snapshot.lastStatus])] : []),
+      text({ fg: colors.muted }, [snapshot.objective]),
     ])
   }])
 }
 
 function GoalKeymapLayerV2(api: TuiPluginV2.Context) {
   api.keymap.layer(() => ({
+    mode: "global",
     commands: [
       {
         id: "goal.show",
@@ -573,8 +629,8 @@ function GoalKeymapLayerV2(api: TuiPluginV2.Context) {
  * needs to dispose the two `ui.slot` registrations.
  */
 export function setupTuiV2(context: TuiPluginV2.Context): TuiPluginV2.Cleanup {
-  const offSidebar = context.ui.slot("sidebar.content", (props) => GoalSidebarV2(context, props.sessionID))
-  const offApp = context.ui.slot("app", () => GoalKeymapLayerV2(context))
+  const offSidebar = registerSlotV2(context, "sidebar.content", (props) => GoalSidebarV2(context, props.sessionID))
+  const offApp = registerSlotV2(context, "app", () => GoalKeymapLayerV2(context))
   return () => {
     offSidebar()
     offApp()

--- a/test/tui-v2.test.ts
+++ b/test/tui-v2.test.ts
@@ -3,7 +3,13 @@ import { testRender } from "@opentui/solid"
 import { createSignal } from "solid-js"
 import { createStore, type Store } from "solid-js/store"
 import type { SessionMessageAssistantTool, SessionMessageInfo } from "@opencode-ai/client"
-import plugin, { goalFromV2Messages, liveTimeUsedSeconds, setupTuiV2 } from "../src/tui.ts"
+import plugin, {
+  goalFromV2Messages,
+  liveTimeUsedSeconds,
+  registerSlotV2,
+  setupTuiV2,
+  themeColorV2,
+} from "../src/tui.ts"
 
 type GoalSnapshot = Parameters<typeof liveTimeUsedSeconds>[0]
 
@@ -105,7 +111,13 @@ type MockContext = {
     }
   }
   attention: unknown
-  theme: { text: string; textMuted: string; primary: string }
+  theme: {
+    text: {
+      default: string
+      subdued: string
+      feedback: { success: { default: string } }
+    }
+  }
   markdown: unknown
   keymap: {
     layer: (input: () => MockKeymapLayer) => void
@@ -136,7 +148,7 @@ type MockContext = {
       current: () => { type: string; sessionID?: string }
     }
     tabs: unknown
-    slot: (name: string, render: (props: { sessionID: string }) => unknown) => () => void
+    slot: (options: { append: string; render: (props: { sessionID: string }) => unknown }) => () => void
   }
 }
 
@@ -185,7 +197,13 @@ function makeMockContext(overrides: Partial<MockContext> = {}): {
       },
     },
     attention: undefined,
-    theme: { text: "#ffffff", textMuted: "#888888", primary: "#00ff00" },
+    theme: {
+      text: {
+        default: "#ffffff",
+        subdued: "#888888",
+        feedback: { success: { default: "#00ff00" } },
+      },
+    },
     markdown: undefined,
     keymap: {
       layer(input) {
@@ -234,10 +252,12 @@ function makeMockContext(overrides: Partial<MockContext> = {}): {
         current: () => route,
       },
       tabs: undefined,
-      slot(name, render) {
-        slots.set(name, render)
+      // Current previews take a single options argument. Keep the arity at 1 so
+      // the plugin exercises the same call shape the real host uses.
+      slot(options) {
+        slots.set(options.append, options.render)
         return () => {
-          disposed.push(name)
+          disposed.push(options.append)
         }
       },
     },
@@ -273,6 +293,68 @@ test("V2 TUI definition exposes id and a setup function", () => {
   expect(plugin.id).toBe("local.goal-mode.tui")
   expect(typeof plugin.setup).toBe("function")
   expect(typeof plugin.tui).toBe("function")
+})
+
+test("registerSlotV2 uses the options argument when the host takes one parameter", () => {
+  const calls: Array<{ append: string; render: unknown }> = []
+  const context = {
+    ui: {
+      slot: (options: { append: string; render: () => unknown }) => {
+        calls.push(options)
+        return () => {}
+      },
+    },
+  }
+  const render = () => null
+
+  const dispose = registerSlotV2(context as never, "sidebar.content", render)
+
+  expect(calls).toEqual([{ append: "sidebar.content", render }])
+  expect(typeof dispose).toBe("function")
+})
+
+test("registerSlotV2 falls back to the positional form on earlier previews", () => {
+  const calls: Array<[string, unknown]> = []
+  const context = {
+    ui: {
+      slot: (name: string, render: () => unknown) => {
+        calls.push([name, render])
+        return () => {}
+      },
+    },
+  }
+  const render = () => null
+
+  registerSlotV2(context as never, "app", render)
+
+  expect(calls).toEqual([["app", render]])
+})
+
+test("registerSlotV2 tolerates hosts that do not return a disposer", () => {
+  const context = { ui: { slot: (_options: { append: string }) => undefined } }
+
+  const dispose = registerSlotV2(context as never, "sidebar.content", () => null)
+
+  expect(typeof dispose).toBe("function")
+  expect(() => dispose()).not.toThrow()
+})
+
+test("themeColorV2 resolves nested, grouped, and legacy flat theme colors", () => {
+  const nested = {
+    text: { default: "#ffffff", subdued: "#888888", feedback: { success: { default: "#00ff00" } } },
+  }
+  const flat = { text: "#eeeeee", textMuted: "#777777", primary: "#00cc00" }
+
+  expect(themeColorV2(nested, ["text", "default"], ["text"])).toBe("#ffffff")
+  expect(themeColorV2(nested, ["text", "subdued"], ["textMuted"])).toBe("#888888")
+  // A color group resolves to its `default` leaf rather than the group object.
+  expect(themeColorV2(nested, ["text", "feedback", "success"], ["primary"])).toBe("#00ff00")
+
+  expect(themeColorV2(flat, ["text", "default"], ["text"])).toBe("#eeeeee")
+  expect(themeColorV2(flat, ["text", "subdued"], ["textMuted"])).toBe("#777777")
+  expect(themeColorV2(flat, ["text", "feedback", "success"], ["primary"])).toBe("#00cc00")
+
+  expect(themeColorV2({}, ["text", "default"], ["text"])).toBeUndefined()
 })
 
 test("V2 setup registers sidebar.content and app slots and cleanup disposes them", () => {
@@ -441,6 +523,9 @@ test("V2 keymap layer registers the goal palette command when the app slot rende
     expect(command).toBeDefined()
     expect(command?.title).toBe("Goal")
     expect(command?.palette).toBe(true)
+    // Without an explicit global mode the host never surfaces the command in
+    // the palette, even while the layer itself is registered.
+    expect(layer?.mode).toBe("global")
     setup.renderer.destroy()
     destroyed = true
   } finally {


### PR DESCRIPTION
## Summary

On current OpenCode 2 previews the V2 TUI integration registers nothing: no goal sidebar, and no `Goal` entry in the `ctrl+p` palette. The server side (tools, `/goal`, persistence) is unaffected, so the plugin looks healthy while its whole TUI surface is dead.

There are three independent breakages, and the first one hides the other two.

**1. `ui.slot` takes a claim object, and the positional form was removed.** Bisecting the published `@opencode-ai/plugin` declarations (`dist/tui/context.d.ts`) pins the change to `0.0.0-next-17226`:

| preview | `ui.slot` |
| --- | --- |
| `0.0.0-next-17055` … `0.0.0-next-17224` | `<Name extends SlotName>(name: Name, render: Slot<Name>) => () => void` |
| `0.0.0-next-17226` and later | `(claim: SlotClaim) => () => void`, carrying `render` plus exactly one of `prepend`/`append`/`before`/`after`/`replace` |

No overload was retained. In the `0.0.0-next-17403` host:

```js
slot(K) {
  let C = `slot#${F++}`,
      X = ["prepend","append","before","after","replace"].filter(W => K[W] !== void 0)
  if (X.length !== 1) throw Error("Slot claim requires exactly one placement key")
  ...
}
```

So `slot("sidebar.content", render)` throws, `setupTuiV2` aborts on its first statement, and the `app` slot — which mounts the keymap layer — is never reached. One throw removes both the sidebar and the palette command.

**2. The sidebar read theme keys that do not exist.** It used `theme.text`, `theme.textMuted` and `theme.primary`, copied from the V1 sidebar. Both preview generations expose a nested theme (`theme.text.default`, `theme.text.subdued`, `theme.text.feedback.success.default`, `theme.text.action.primary`): the last two flat keys are `undefined` and `theme.text` is a colour *group*, not a colour. This was already wrong on `0.0.0-next-17055` (`theme.primary` does not occur in that binary at all), so it never worked — it was simply unreachable behind breakage 1.

**3. The keymap layer never opted into the global mode.** `goal.show` sets `palette: true` but the layer omitted `mode`, which the plugin contract has documented since `0.0.0-next-17055` ("Limits the layer to one OpenCode input mode. Use global to opt out; defaults to base."). Without it the layer registers but the palette never lists the command; every host built-in exposing a palette command declares `mode: "global"`.

## Related issue

None open — filed directly from a live V2 debugging session.

## Changes

- `src/tui.ts`: add `registerSlotV2()`, which branches on `context.ui.slot.length` — one parameter means the claim-object host, two means the pre-17226 host. Both shipped generations were checked directly: `0.0.0-next-17403` implements `slot(K)` (arity 1) and `0.0.0-next-17055` implements `slot(Q, X)` (arity 2). It also tolerates a host that returns no disposer.
- `src/tui.ts`: add `themeColorV2()` + `goalColorsV2()`, resolving the first candidate theme path that exists and descending into a `default` leaf when the node is a colour group. Nested paths are tried first, legacy flat keys remain as fallbacks, so one path serves both generations. `element()` already skips `undefined` props, so an unresolved colour degrades to the inherited default rather than throwing.
- `src/tui.ts`: `setupTuiV2()` registers both slots through the adapter; `GoalKeymapLayerV2()` declares `mode: "global"`.
- `test/tui-v2.test.ts`: update the mock to the current host contract (arity-1 `slot`, nested theme) and add coverage for the claim-object host, the positional fallback, a host returning no disposer, `themeColorV2` across nested/grouped/flat themes, and the `mode: "global"` assertion.

Only V2 code paths are touched: the V1 integration still uses `api.theme.current` with flat keys and is unchanged.

The old mock encoded the outdated contract (`slot(name, render)`, `{ text, textMuted, primary }`), which is why the suite stayed green against an API that no longer exists. Reverting just the call shape in `registerSlotV2` now fails **8 tests** in that file, where previously it failed none.

## Verification

Gates:

```
bun run lint        clean
bun run typecheck   clean
bun test            98 pass / 0 fail (370 assertions, 6 files)
bun run build       dist/server.js 95.30 KB
bun run pack:dry-run  ships dist, src/tui.ts, LICENSE, README
```

End to end against **`opencode2 0.0.0-next-17403`** (claim-object host), plugin loaded from this working copy, isolated `OPENCODE_DB` and `OPENCODE_GOAL_STATE_PATH`, driven in tmux:

- sidebar renders `Goal` / `Status: active` / `Time: …` / `Tokens: …` / `Auto-continues: …` / `Goal set.` / objective, and `Time:` ticks while the goal is active
- palette lists `Goal`; selecting it opens the dialog with the objective plus Refresh / History / Pause / Clear, and Refresh prompts the agent
- `/goal pause` → `Status: paused` + `Stop: paused`; `/goal complete …` → `Goal achieved (1:13)`, exercising the `text.feedback.success` group descent
- state survives a restart with `-c`; invoking the command with no session open toasts "Open a session before viewing goal state." instead of crashing
- exactly one Goal block throughout, across four `setup` activations during one boot

Colour resolution confirmed byte-exact by matching the pane's ANSI codes to the host theme: header `38;2;205;214;244` = `text.default`, detail lines `38;2;147;153;178` = `text.subdued`, `Goal achieved` `38;2;166;227;161` = `text.feedback.success.default`.

Re-run against **`opencode2 0.0.0-next-17055`** (positional host) in a pinned `linux/arm64` container, configured the way that era expects — `~/.config/opencode/tui.json` with a relative plugin path, since `cli.json` only appears with the 17403-era migration. The adapter reported `slotArity: 2`, took the positional branch, `setup` returned a cleanup function, the palette listed `Goal`, and `/goal …` rendered the sidebar. (The preview CLI silently self-updates; `OPENCODE_DISABLE_AUTOUPDATE=1` is needed to keep an old preview under test.)

| host | `slot` arity | branch taken | palette | sidebar |
| --- | --- | --- | --- | --- |
| `0.0.0-next-17403` | 1 | claim object | yes | yes |
| `0.0.0-next-17055` | 2 | positional | yes | yes |

## Checklist

- [x] `bun test` passes (new behavior has regression coverage)
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run build` passes and `dist/server.js` is committed if server code changed — build is clean; `src/server.ts` and its imports are untouched (`src/server.ts` does not import `src/tui.ts`) and the rebuilt bundle is byte-identical, so there is no `dist` change to commit
- [x] README/docs updated if behavior or options changed — no options or documented behavior changed; the README already lists TUI sidebar/palette integration as V2-supported, which this restores

## Notes for review

- The arity check is a heuristic. It is correct on both shipped generations, but a host that wrapped `slot` variadically would defeat it, and guessing the claim object on a legacy host fails *silently* whereas the reverse throws loudly. `try { slot(claim) } catch { slot(name, render) }` would key off the observable throw instead — happy to switch if you prefer.
- `goalColorsV2` is evaluated in the component body rather than inside the render closure, so a runtime theme switch will not restyle an open sidebar. That matches the previous `const theme = api.theme` behaviour, so it is not a regression, but the host's built-ins read theme values inside their render effects and this could follow suit.
- `registerSlotV2` and `themeColorV2` are exported for tests; both are reachable through `setupTuiV2` with two mock variants if you would rather not widen the published surface of `./tui`.
- The cast on `context.ui.slot` is needed because the pinned `@opencode-ai/plugin-v2` (`npm:@opencode-ai/plugin@0.0.0-next-17055`) still declares the positional signature. Bumping that pin past `0.0.0-next-17226` would let the claim-object call type-check directly.

## AI attribution

Written with the OpenCode 2 agent harness (`opencode2`) using Anthropic Claude Opus 5. All verification above — unit gates, both live host runs, and the type-declaration bisection — was executed, and the diff was reviewed by the submitter before opening this PR.
