### PR TITLE
ci: serialize stateful tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 
 ## Checklist
 
-- [ ] `bun test` passes (new behavior has regression coverage)
+- [ ] `bun run test` passes (new behavior has regression coverage)
 - [ ] `bun run lint` passes
 - [ ] `bun run typecheck` passes
 - [ ] `bun run build` passes and `dist/server.js` is committed if server code changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Run tests with coverage
         run: |
-          bun test --coverage 2>&1 | tee test-output.log
+          bun run test:coverage 2>&1 | tee test-output.log
       - name: Publish coverage summary
         if: always()
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
-      - run: bun test
+      - run: bun run test
 
   publish:
     name: Publish to npm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Before treating a code change as complete, run the relevant checks. For release-
 ```bash
 bun run lint
 bun run typecheck
-bun test
+bun run test
 bun run build
 bun run pack:dry-run
 ```
@@ -46,7 +46,7 @@ gh release view v<version>
 
 ## End-To-End Plugin Test
 
-To test this plugin end to end, do not stop at unit tests. Run the local gates first: `bun run lint`, `bun run typecheck`, `bun test`, `bun run build`, and `bun run pack:dry-run`.
+To test this plugin end to end, do not stop at unit tests. Run the local gates first: `bun run lint`, `bun run typecheck`, `bun run test`, `bun run build`, and `bun run pack:dry-run`.
 
 After publishing, verify the exact npm version with `npm view @prevalentware/opencode-goal-plugin version dependencies`. Install that version in an isolated temp OpenCode project with `opencode plugin @prevalentware/opencode-goal-plugin@<version>`, run `opencode debug config` to confirm the package is loaded and the `goal` command is registered, then run a smoke test with an isolated state file, for example:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ Useful scripts:
 
 | Script | What it does |
 | --- | --- |
-| `bun test` | Run the unit test suite |
-| `bun test --coverage` | Run tests with a coverage report |
+| `bun run test` | Run the unit test suite serially |
+| `bun run test:coverage` | Run the serial test suite with a coverage report |
 | `bun run lint` | ESLint over the repo |
 | `bun run typecheck` | TypeScript `--noEmit` check |
 | `bun run build` | Bundle `src/server.ts` into `dist/` |
@@ -40,7 +40,7 @@ Useful scripts:
 1. Create a topic branch from `main`.
 2. Make your change, keeping the existing code style (no semicolons, 130-column lines, strict TypeScript).
 3. Add or update tests — behavior changes need regression coverage.
-4. Run the local gates: `bun test && bun run lint && bun run typecheck && bun run build`.
+4. Run the local gates: `bun run test && bun run lint && bun run typecheck && bun run build`.
 5. Commit the rebuilt `dist/server.js` when `src/server.ts` (or its imports) changed — the built file is tracked on purpose.
 6. Open a pull request against `main` describing the problem, the approach, and how you verified it. Link the related issue (`Closes #NN`) when one exists. The pull request description must also name the AI model and agent harness used (for example, OpenCode or Claude Code), or explicitly state that the change was made manually.
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This plugin follows Codex's native goal-mode semantics where OpenCode plugin hoo
 
 ```bash
 bun install
-bun test
+bun run test
 bun run lint
 bun run typecheck
 bun run build

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "ci:version": "bun scripts/resolve-ci-version.ts",
     "lint": "eslint .",
     "pack:dry-run": "npm pack --dry-run",
-    "test": "bun test",
+    "test": "bun test --concurrent --max-concurrency 1",
+    "test:coverage": "bun test --concurrent --max-concurrency 1 --coverage",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run test && bun run build"
   },


### PR DESCRIPTION
## Summary

- run the stateful Bun suite through a globally single-test scheduler
- centralize normal and coverage commands as `bun run test` and `bun run test:coverage`
- use those scripts in PR CI, publishing, and contributor documentation

## Root cause

The tests isolate state with `OPENCODE_GOAL_STATE_PATH`, but that environment variable, fake system time, and the state mutation queue are process-global. During a failing plan-agent test, instrumentation captured another test's objective (`native retry must win`) in its state. This made timing assertions and goal lifecycle assertions nondeterministic.

`--max-concurrency 1` alone did not stop cross-file interference on Bun 1.3.8. Routing all tests through the concurrent scheduler and limiting it to one did.

## Validation

- plain runner reproduced failures in 2/12 full-suite loops
- V2-only runner reproduced failures in 2/50 loops
- fixed runner passed 20/20 full-suite loops
- `bun run lint`
- `bun run typecheck`
- `bun run test` (212 pass)
- `bun run test:coverage` (212 pass)
- `bun run build`
- `bun run pack:dry-run`
- Claude Opus review: no merge blocker