### PR TITLE
test: allow restart recovery to settle

### DIFF
--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -2390,7 +2390,7 @@ test("restart resolves a persisted started pending attempt at the next idle", as
   const context = { sessionID: "ses_1" } as never
   await requireTool(tools1.create_goal, "create_goal").execute({ objective: "keep going" }, context)
   await hooks1.event!({ event: { type: "session.idle", properties: { sessionID: "ses_1" } } as never })
-  await waitFor(() => firstCalls.length === 1)
+  await waitForLong(() => firstCalls.length === 1, 5_000)
   await hooks1.event!({
     event: { type: "session.status", properties: { sessionID: "ses_1", status: { type: "busy" } } } as never,
   })


### PR DESCRIPTION
## Summary

- use the existing long-wait helper for restart recovery
- allow up to 5 seconds under publish-job I/O load while still returning immediately on success

## Evidence

The normal unit job passed, while npm `prepublishOnly` failed only because the generic 2-second polling deadline expired at `test/server.test.ts:2393`. The same test normally completes in about 40 ms.

## Validation

- focused restart test: 100/100 passes
- `bun run lint`
- `bun run typecheck`
- `bun run test` (213 pass)
- `bun run test:coverage` (213 pass)
- `bun run build`
- `bun run pack:dry-run`