### PR TITLE
ci: avoid rerunning tests during publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       - run: bun run build
-      - run: npm publish
+      - run: npm publish --ignore-scripts
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- publish with `--ignore-scripts` after the workflow test gate and explicit build
- preserve `prepublishOnly` for local/manual publishes

## Why
The publish workflow already requires unit tests, lint, and typecheck, then builds before `npm publish`. Running `prepublishOnly` repeats all tests inside the publish step and caused unrelated timing/GC flakes to block v0.1.39 after the required test job had passed.