### PR TITLE
fix: decode V2 event stream payloads

### DIFF
--- a/dist/server.js
+++ b/dist/server.js
@@ -1875,6 +1875,21 @@ function v2ObjectSchema(properties, required = []) {
     additionalProperties: false
   };
 }
+function decodeV2Event(value) {
+  let decoded = value;
+  if (typeof decoded === "string") {
+    try {
+      decoded = JSON.parse(decoded);
+    } catch {
+      return;
+    }
+  }
+  if (!isRecord(decoded) || typeof decoded.type !== "string" || !isRecord(decoded.data))
+    return;
+  if (typeof decoded.created !== "number")
+    return;
+  return decoded;
+}
 function textFromToolResult(result) {
   if (typeof result.output === "string")
     return result.output;
@@ -3031,7 +3046,9 @@ async function setupV2(context) {
         const { done, value } = await iterator.next();
         if (done)
           break;
-        await handleV2Event(value);
+        const event = decodeV2Event(value);
+        if (event)
+          await handleV2Event(event);
       }
     } catch (error) {
       if (!abortController.signal.aborted)

--- a/src/server.ts
+++ b/src/server.ts
@@ -885,6 +885,20 @@ type V2EventLike = {
   data: Record<string, unknown>
 }
 
+function decodeV2Event(value: unknown): V2EventLike | undefined {
+  let decoded = value
+  if (typeof decoded === "string") {
+    try {
+      decoded = JSON.parse(decoded)
+    } catch {
+      return undefined
+    }
+  }
+  if (!isRecord(decoded) || typeof decoded.type !== "string" || !isRecord(decoded.data)) return undefined
+  if (typeof decoded.created !== "number") return undefined
+  return decoded as V2EventLike
+}
+
 type V2StepRecord = {
   messageID: string
   agent?: string
@@ -2168,7 +2182,8 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
       while (true) {
         const { done, value } = await iterator.next()
         if (done) break
-        await handleV2Event(value as V2EventLike)
+        const event = decodeV2Event(value)
+        if (event) await handleV2Event(event)
       }
     } catch (error) {
       if (!abortController.signal.aborted) v2ErrorLog("V2 event consumer stopped", error)

--- a/test/server-v2.test.ts
+++ b/test/server-v2.test.ts
@@ -562,6 +562,22 @@ test("V2 idle event triggers auto-continue via ctx.session.prompt", async () => 
   await cleanup()
 })
 
+test("V2 JSON-encoded idle event triggers auto-continue", async () => {
+  const mock = makeMockContext({ auto_continue: true, min_continue_interval_seconds: 0, max_auto_turns: 5 })
+  const cleanup = await setupPlugin(mock as never)
+  await createGoalViaV2Tool(mock, "auto-continue from encoded idle events")
+
+  mock.stream.push("not JSON")
+  mock.stream.push(JSON.stringify({ type: "session.idle", created: Date.now(), data: { sessionID: "ses_v2" } }))
+
+  await waitFor(() => mock.promptCalls.length === 1)
+  expect(mock.promptCalls[0]?.sessionID).toBe("ses_v2")
+  expect((await getGoal("ses_v2"))?.autoTurns).toBe(1)
+
+  mock.stream.end()
+  await cleanup()
+})
+
 test("V2 idle continuation waits for a running child session", async () => {
   const mock = makeMockContext({ min_continue_interval_seconds: 1 })
   const cleanup = await setupPlugin(mock as never)


### PR DESCRIPTION
## Problem

OpenCode V2 exposes event stream items as `V2EventEncoded`, a JSON string. The plugin currently casts each item directly to `V2EventLike`. Accessing `event.data.sessionID` on the first encoded event throws, stops the event consumer, and leaves active goals without idle auto-continuation.

Observed with OpenCode `0.0.0-beta-18866` and goal plugin `0.1.39`. The running server's OpenAPI schema describes `V2EventEncoded` as a string with `contentMediaType: application/json`.

## Change

- Decode JSON string events before dispatch while retaining object-event compatibility.
- Ignore malformed or structurally invalid events instead of terminating the consumer.
- Add a regression test proving a malformed item followed by an encoded `session.idle` still triggers exactly one continuation.
- Rebuild `dist/server.js`.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test` (214 passed)
- `bun run build`
- `bun run pack:dry-run`

AI assistance: GPT-5.3 Codex via OpenCode.
