### PR TITLE
test: close file handles in failure mocks

### DIFF
--- a/test/atomic-write.test.ts
+++ b/test/atomic-write.test.ts
@@ -70,9 +70,16 @@ function makeRecordingOps(overrides: { ops?: Partial<AtomicWriteOps>; handle?: P
           record("sync", [])
           return overrides.handle?.sync ? overrides.handle.sync() : inner.sync()
         },
-        close: () => {
+        close: async () => {
           record("close", [])
-          return overrides.handle?.close ? overrides.handle.close() : inner.close()
+          if (!overrides.handle?.close) return inner.close()
+          try {
+            await overrides.handle.close()
+          } catch (error) {
+            await inner.close()
+            throw error
+          }
+          return inner.close()
         },
       }
     },


### PR DESCRIPTION
## Summary
- close the real temporary-file handle even when a test override simulates a close failure
- preserve the simulated error and existing operation-order assertions
- unblock the Publish workflow under Bun 1.4.0, which now treats GC-closed FileHandles as errors

## Verification
- Bun 1.4.0 full suite: 213 passing, 0 failures, 0 errors
- Bun 1.3.8 atomic-write suite: 29 passing
- bun run lint
- bun run typecheck
- bun run build
- bun run pack:dry-run
- Claude Opus review: APPROVE