### PR TITLE
fix: pause compatibility commands before admission

### DIFF
--- a/dist/server.js
+++ b/dist/server.js
@@ -3185,6 +3185,24 @@ async function setupV2(context) {
         });
       }
     }));
+    registrations.push(await context.session.hook("prompt", async (input) => {
+      const pauseTemplate = goalStatusCommandTemplate("pause_goal");
+      const resumeTemplate = goalStatusCommandTemplate("resume_goal");
+      const template = input.prompt.text.startsWith(pauseTemplate) ? pauseTemplate : input.prompt.text.startsWith(resumeTemplate) ? resumeTemplate : null;
+      if (!template)
+        return;
+      input.prompt.text = template;
+      delete input.prompt.files;
+      delete input.prompt.agents;
+      delete input.prompt.skills;
+      if (template !== pauseTemplate)
+        return;
+      const goal = await getGoal(input.sessionID);
+      if (goal?.status === "active")
+        await setGoalStatus(input.sessionID, "paused");
+      cancelScheduledContinuation(input.sessionID);
+      clearTurnWatchdog(input.sessionID);
+    }));
   }
   registrations.push(await context.tool.transform((draft) => {
     for (const tool of goalToolsV2(goalServices))

--- a/src/server.ts
+++ b/src/server.ts
@@ -2235,6 +2235,30 @@ async function setupV2(context: PluginV2.Plugin.Context): Promise<PluginV2.Plugi
         }
       }),
     )
+
+    // V1-compatible config commands bypass V2 command executors, so enforce
+    // their lifecycle action again at the shared prompt-admission boundary.
+    registrations.push(
+      await context.session.hook("prompt", async (input) => {
+        const pauseTemplate = goalStatusCommandTemplate("pause_goal")
+        const resumeTemplate = goalStatusCommandTemplate("resume_goal")
+        const template = input.prompt.text.startsWith(pauseTemplate)
+          ? pauseTemplate
+          : input.prompt.text.startsWith(resumeTemplate)
+            ? resumeTemplate
+            : null
+        if (!template) return
+        input.prompt.text = template
+        delete input.prompt.files
+        delete input.prompt.agents
+        delete input.prompt.skills
+        if (template !== pauseTemplate) return
+        const goal = await getGoal(input.sessionID)
+        if (goal?.status === "active") await setGoalStatus(input.sessionID, "paused")
+        cancelScheduledContinuation(input.sessionID)
+        clearTurnWatchdog(input.sessionID)
+      }),
+    )
   }
 
   registrations.push(

--- a/test/server-v2.test.ts
+++ b/test/server-v2.test.ts
@@ -399,6 +399,57 @@ test("V2 setup preserves existing commands and configured command-name collision
   await cleanup()
 })
 
+test("V2 prompt hook pauses compatibility commands before admission", async () => {
+  const mock = makeMockContext({ auto_continue: false }, ["goal", "pause_goal", "resume_goal"])
+  const cleanup = await setupPlugin(mock as never)
+  await createGoalViaV2Tool(mock, "pause before acknowledgement")
+  const v1 = await plugin.server({ client: { session: { promptAsync: async () => {} } } } as never, {
+    auto_continue: false,
+  })
+  const config = {} as { command?: Record<string, { template: string }> }
+  await v1.config?.(config as never)
+  const pauseTemplate = config.command?.pause_goal?.template
+  const resumeTemplate = config.command?.resume_goal?.template
+  if (!pauseTemplate) throw new Error("expected pause_goal compatibility command")
+  if (!resumeTemplate) throw new Error("expected resume_goal compatibility command")
+  await v1.dispose?.()
+  const input = {
+    sessionID: "ses_v2",
+    messageID: "msg_pause",
+    prompt: {
+      text: `${pauseTemplate}\nuntrusted arguments`,
+      files: [{ uri: "file:///tmp/untrusted.txt" }],
+      agents: [{ name: "plan" }],
+      skills: [{ id: "untrusted" }],
+    },
+    delivery: "steer",
+  }
+
+  await mock.hooks.prompt?.(input)
+
+  expect(await getGoal("ses_v2")).toMatchObject({ status: "paused", objective: "pause before acknowledgement" })
+  expect(input.prompt.text).toBe(pauseTemplate)
+  expect(input.prompt.files).toBeUndefined()
+  expect(input.prompt.agents).toBeUndefined()
+  expect(input.prompt.skills).toBeUndefined()
+
+  const resumeInput = {
+    sessionID: "ses_v2",
+    messageID: "msg_resume",
+    prompt: {
+      text: `${resumeTemplate}\nuntrusted arguments`,
+      files: [{ uri: "file:///tmp/untrusted.txt" }],
+    },
+    delivery: "steer",
+  }
+  await mock.hooks.prompt?.(resumeInput)
+  expect((await getGoal("ses_v2"))?.status).toBe("paused")
+  expect(resumeInput.prompt.text).toBe(resumeTemplate)
+  expect(resumeInput.prompt.files).toBeUndefined()
+  mock.stream.end()
+  await cleanup()
+})
+
 test("V2 command transform remains stable when the registry replays it", async () => {
   const mock = makeMockContext({ auto_continue: false })
   let transform: ((draft: MockCommandDraft) => void) | undefined
@@ -463,6 +514,7 @@ test("V2 setup skips command registration when register_command is false", async
 
   expect(mock.commands).toHaveLength(0)
   expect(mock.disposals).not.toContain("command.transform")
+  expect(mock.hooks.prompt).toBeUndefined()
 
   mock.stream.end()
   await cleanup()
@@ -757,7 +809,14 @@ test("V2 cleanup disposes registrations and stops the event consumer", async () 
   await cleanup()
 
   expect(mock.disposals).toEqual(
-    expect.arrayContaining(["command.transform", "tool.transform", "tool.hook:execute.before", "tool.hook:execute.after", "session.hook:context"]),
+    expect.arrayContaining([
+      "command.transform",
+      "session.hook:prompt",
+      "tool.transform",
+      "tool.hook:execute.before",
+      "tool.hook:execute.after",
+      "session.hook:context",
+    ]),
   )
   // Events pushed after cleanup must not throw or mutate state.
   mock.stream.push({


### PR DESCRIPTION
## Summary

- enforce `/pause_goal` at the V2 prompt-admission boundary when OpenCode executes the V1-compatible static command definition instead of the V2 command executor
- sanitize appended arguments and attachments for both static `/pause_goal` and `/resume_goal` prompts
- keep resume model-mediated so existing Plan-mode enforcement remains authoritative
- register/dispose the fallback only when command registration is enabled
- add a regression reproducing the real V1-command/V2-runtime order and cleanup assertions

## Reproduction

After installing `0.1.43`, an OpenCode V2 standalone smoke showed `/pause_goal` calling `get_goal` while the goal was still `active`; it only became paused after the model called `update_goal_status`. With this change loaded from `dist/server.js`, the model context already observes the paused goal and no active-state `get_goal` occurs.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test` (231 passing)
- `bun run build`
- `bun run pack:dry-run`
- real OpenCode V2 `v0.0.0-beta-18593` standalone smoke with isolated goal state
- internal correctness review: approved
- internal standards review: approved

Follow-up to #36 and #44.

AI assistance: diagnosed from an end-to-end smoke, implemented, and reviewed with OpenCode agents; an independent Claude Opus review will be attached before merge.